### PR TITLE
Fix camera control axes for KH2 motion editor

### DIFF
--- a/OpenKh.Tools.Kh2MsetMotionEditor/App.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/App.cs
@@ -503,9 +503,9 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor
                 camera.CameraPosition -= Vector3.Multiply(camera.CameraLookAtZ, moveSpeed * 5);
 
             if (keyboard.IsKeyDown(Keys.Up))
-                camera.CameraRotationYawPitchRoll += new Vector3(0, 0, 1 * speed);
+                camera.CameraRotationYawPitchRoll += new Vector3(0, 1 * speed, 0);
             if (keyboard.IsKeyDown(Keys.Down))
-                camera.CameraRotationYawPitchRoll -= new Vector3(0, 0, 1 * speed);
+                camera.CameraRotationYawPitchRoll -= new Vector3(0, 1 * speed, 0);
             if (keyboard.IsKeyDown(Keys.Left))
                 camera.CameraRotationYawPitchRoll += new Vector3(1 * speed, 0, 0);
             if (keyboard.IsKeyDown(Keys.Right))
@@ -521,7 +521,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor
                 var xSpeed = (_previousMousePosition.X - mouse.Position.X) * Speed;
                 var ySpeed = (_previousMousePosition.Y - mouse.Position.Y) * Speed;
                 camera.CameraRotationYawPitchRoll += new Vector3(1 * -xSpeed, 0, 0);
-                camera.CameraRotationYawPitchRoll += new Vector3(0, 0, 1 * ySpeed);
+                camera.CameraRotationYawPitchRoll += new Vector3(0, 1 * ySpeed, 0);
             }
 
             _previousMousePosition = mouse.Position;

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
@@ -10,9 +10,9 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
         {
             ForEdit3("Position", () => camera.CameraPosition, x => camera.CameraPosition = x);
             ForEdit2("Rotation",
-                () => new Vector2(-camera.CameraRotationYawPitchRoll.X, -camera.CameraRotationYawPitchRoll.Z),
+                () => new Vector2(-camera.CameraRotationYawPitchRoll.X, -camera.CameraRotationYawPitchRoll.Y),
                 x => camera.CameraRotationYawPitchRoll = new Vector3(
-                    -x.X, camera.CameraRotationYawPitchRoll.Y, -x.Y));
+                    -x.X, -x.Y, camera.CameraRotationYawPitchRoll.Z));
         });
     }
 }


### PR DESCRIPTION
## Summary
- adjust pitch with arrows and mouse drag
- show yaw & pitch in the camera inspector

## Testing
- `dotnet build --no-restore OpenKh.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e6cb142388329ad2828556bb68601