### PR TITLE
Move camera tool to own window

### DIFF
--- a/OpenKh.Tools.Kh2MsetMotionEditor/App.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/App.cs
@@ -540,6 +540,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor
 
             var newRot = camera.CameraRotationYawPitchRoll;
             if (_cameraLockOptions.LockRotX) newRot.X = prevRot.X;
+            if (_cameraLockOptions.LockRotY) newRot.Y = prevRot.Y;
             if (_cameraLockOptions.LockRotZ) newRot.Z = prevRot.Z;
             camera.CameraRotationYawPitchRoll = newRot;
         }
@@ -566,6 +567,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor
 
                 var rotAfter = camera.CameraRotationYawPitchRoll;
                 if (_cameraLockOptions.LockRotX) rotAfter.X = prevRot.X;
+                if (_cameraLockOptions.LockRotY) rotAfter.Y = prevRot.Y;
                 if (_cameraLockOptions.LockRotZ) rotAfter.Z = prevRot.Z;
                 camera.CameraRotationYawPitchRoll = rotAfter;
 

--- a/OpenKh.Tools.Kh2MsetMotionEditor/App.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/App.cs
@@ -540,7 +540,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor
 
             var newRot = camera.CameraRotationYawPitchRoll;
             if (_cameraLockOptions.LockRotX) newRot.X = prevRot.X;
-            if (_cameraLockOptions.LockRotY) newRot.Y = prevRot.Y;
+            if (_cameraLockOptions.LockRotZ) newRot.Z = prevRot.Z;
             camera.CameraRotationYawPitchRoll = newRot;
         }
 
@@ -566,7 +566,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor
 
                 var rotAfter = camera.CameraRotationYawPitchRoll;
                 if (_cameraLockOptions.LockRotX) rotAfter.X = prevRot.X;
-                if (_cameraLockOptions.LockRotY) rotAfter.Y = prevRot.Y;
+                if (_cameraLockOptions.LockRotZ) rotAfter.Z = prevRot.Z;
                 camera.CameraRotationYawPitchRoll = rotAfter;
 
                 var viewport = _graphicsDevice.Viewport;

--- a/OpenKh.Tools.Kh2MsetMotionEditor/DependencyInjection/UseExtensions.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/DependencyInjection/UseExtensions.cs
@@ -90,6 +90,8 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.DependencyInjection
                 sp => sp.GetRequiredService<MonoGameImGuiBootstrap>().Content
             );
 
+            self.AddSingleton<CameraLockOptions>();
+
             self.AddSingleton(
                 sp => sp.GetRequiredService<MonoGameImGuiBootstrap>().GraphicsDevice
             );
@@ -117,6 +119,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.DependencyInjection
             self.AddSingleton<IWindowRunnableProvider, FCurveKeyManagerWindowUsecase>();
             self.AddSingleton<IWindowRunnableProvider, FCurvesFkIkGridManagerWindow>();
             self.AddSingleton<IWindowRunnableProvider, NormalMessagesWindowUsecase>();
+            self.AddSingleton<IWindowRunnableProvider, CameraWindowUsecase>();
 
 
 

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Helpers/CameraLockOptions.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Helpers/CameraLockOptions.cs
@@ -8,5 +8,6 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Helpers
         public bool LockPosX { get; set; }
         public bool LockPosY { get; set; }
         public bool LockPosZ { get; set; }
+        public bool FollowRootBone { get; set; }
     }
 }

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Helpers/CameraLockOptions.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Helpers/CameraLockOptions.cs
@@ -3,7 +3,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Helpers
     public class CameraLockOptions
     {
         public bool LockRotX { get; set; }
-        public bool LockRotY { get; set; }
+        public bool LockRotZ { get; set; }
         public bool LockPosX { get; set; }
         public bool LockPosY { get; set; }
         public bool LockPosZ { get; set; }

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Helpers/CameraLockOptions.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Helpers/CameraLockOptions.cs
@@ -1,0 +1,11 @@
+namespace OpenKh.Tools.Kh2MsetMotionEditor.Helpers
+{
+    public class CameraLockOptions
+    {
+        public bool LockRotX { get; set; }
+        public bool LockRotY { get; set; }
+        public bool LockPosX { get; set; }
+        public bool LockPosY { get; set; }
+        public bool LockPosZ { get; set; }
+    }
+}

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Helpers/CameraLockOptions.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Helpers/CameraLockOptions.cs
@@ -3,6 +3,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Helpers
     public class CameraLockOptions
     {
         public bool LockRotX { get; set; }
+        public bool LockRotY { get; set; }
         public bool LockRotZ { get; set; }
         public bool LockPosX { get; set; }
         public bool LockPosY { get; set; }

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/ImGuiWindows/CameraWindowUsecase.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/ImGuiWindows/CameraWindowUsecase.cs
@@ -1,0 +1,38 @@
+using OpenKh.Engine;
+using OpenKh.Tools.Kh2MsetMotionEditor.Helpers;
+using OpenKh.Tools.Kh2MsetMotionEditor.Interfaces;
+using System;
+using static OpenKh.Tools.Common.CustomImGui.ImGuiEx;
+
+namespace OpenKh.Tools.Kh2MsetMotionEditor.Usecases.ImGuiWindows
+{
+    public class CameraWindowUsecase : IWindowRunnableProvider
+    {
+        private readonly Camera _camera;
+        private readonly Settings _settings;
+        private readonly CameraLockOptions _locks;
+
+        public CameraWindowUsecase(Settings settings, Camera camera, CameraLockOptions locks)
+        {
+            _settings = settings;
+            _camera = camera;
+            _locks = locks;
+        }
+
+        public Action CreateWindowRunnable()
+        {
+            return () =>
+            {
+                if (_settings.ViewCamera)
+                {
+                    var closed = !ForWindow("Camera", () => CameraWindow.Run(_camera, _locks));
+                    if (closed)
+                    {
+                        _settings.ViewCamera = false;
+                        _settings.Save();
+                    }
+                }
+            };
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/ImGuiWindows/CameraWindowUsecase.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/ImGuiWindows/CameraWindowUsecase.cs
@@ -1,6 +1,7 @@
 using OpenKh.Engine;
 using OpenKh.Tools.Kh2MsetMotionEditor.Helpers;
 using OpenKh.Tools.Kh2MsetMotionEditor.Interfaces;
+using OpenKh.Tools.Kh2MsetMotionEditor.Windows;
 using System;
 using static OpenKh.Tools.Common.CustomImGui.ImGuiEx;
 

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/InsideTools/MotionPlayerToolUsecase.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/InsideTools/MotionPlayerToolUsecase.cs
@@ -109,6 +109,11 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Usecases.InsideTools
                 {
                     _settings.ViewRootPosition = true;
                 }
+                ImGui.SameLine();
+                if (ImGui.Button("Camera"))
+                {
+                    _settings.ViewCamera = true;
+                }
 
                 if (saved)
                 {

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
@@ -10,7 +10,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
     {
         public static bool Run(Camera camera) => Run(camera, new CameraLockOptions());
 
-        public static bool Run(Camera camera, CameraLockOptions locks) => ForHeader("Camera", () =>
+        public static bool Run(Camera camera, CameraLockOptions locks)
         {
             ForEdit("Lock X rotation", () => locks.LockRotX, x => locks.LockRotX = x);
             ForEdit("Lock Z rotation", () => locks.LockRotZ, x => locks.LockRotZ = x);
@@ -41,9 +41,13 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
             camera.CameraPosition = posAfter;
 
             var rotAfter = camera.CameraRotationYawPitchRoll;
-            if (locks.LockRotX && !(rotChanged && rotVec.X != -rotBefore.X)) rotAfter.X = rotBefore.X;
-            if (locks.LockRotZ && !(rotChanged && rotVec.Y != -rotBefore.Z)) rotAfter.Z = rotBefore.Z;
+            if (locks.LockRotX && !(rotChanged && rotVec.X != -rotBefore.X))
+                rotAfter.X = rotBefore.X;
+            if (locks.LockRotZ && !(rotChanged && rotVec.Y != -rotBefore.Z))
+                rotAfter.Z = rotBefore.Z;
             camera.CameraRotationYawPitchRoll = rotAfter;
-        });
+
+            return true;
+        }
     }
 }

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
@@ -13,7 +13,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
         public static bool Run(Camera camera, CameraLockOptions locks) => ForHeader("Camera", () =>
         {
             ForEdit("Lock X rotation", () => locks.LockRotX, x => locks.LockRotX = x);
-            ForEdit("Lock Y rotation", () => locks.LockRotY, x => locks.LockRotY = x);
+            ForEdit("Lock Z rotation", () => locks.LockRotZ, x => locks.LockRotZ = x);
             ForEdit("Lock X position", () => locks.LockPosX, x => locks.LockPosX = x);
             ForEdit("Lock Y position", () => locks.LockPosY, x => locks.LockPosY = x);
             ForEdit("Lock Z position", () => locks.LockPosZ, x => locks.LockPosZ = x);
@@ -34,7 +34,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
 
             var rotAfter = camera.CameraRotationYawPitchRoll;
             if (locks.LockRotX) rotAfter.X = rotBefore.X;
-            if (locks.LockRotY) rotAfter.Y = rotBefore.Y;
+            if (locks.LockRotZ) rotAfter.Z = rotBefore.Z;
             camera.CameraRotationYawPitchRoll = rotAfter;
         });
     }

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
@@ -12,11 +12,6 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
 
         public static bool Run(Camera camera, CameraLockOptions locks)
         {
-            ForEdit("Lock X rotation", () => locks.LockRotX, x => locks.LockRotX = x);
-            ForEdit("Lock Z rotation", () => locks.LockRotZ, x => locks.LockRotZ = x);
-            ForEdit("Lock X position", () => locks.LockPosX, x => locks.LockPosX = x);
-            ForEdit("Lock Y position", () => locks.LockPosY, x => locks.LockPosY = x);
-            ForEdit("Lock Z position", () => locks.LockPosZ, x => locks.LockPosZ = x);
 
             var posBefore = camera.CameraPosition;
             var rotBefore = camera.CameraRotationYawPitchRoll;
@@ -43,9 +38,21 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
             var rotAfter = camera.CameraRotationYawPitchRoll;
             if (locks.LockRotX && !(rotChanged && rotVec.X != -rotBefore.X))
                 rotAfter.X = rotBefore.X;
+            if (locks.LockRotY)
+                rotAfter.Y = rotBefore.Y;
             if (locks.LockRotZ && !(rotChanged && rotVec.Y != -rotBefore.Z))
                 rotAfter.Z = rotBefore.Z;
             camera.CameraRotationYawPitchRoll = rotAfter;
+
+            ForHeader("Camera Locks", () =>
+            {
+                ForEdit("Lock X rotation", () => locks.LockRotX, x => locks.LockRotX = x);
+                ForEdit("Lock Y rotation", () => locks.LockRotY, x => locks.LockRotY = x);
+                ForEdit("Lock Z rotation", () => locks.LockRotZ, x => locks.LockRotZ = x);
+                ForEdit("Lock X position", () => locks.LockPosX, x => locks.LockPosX = x);
+                ForEdit("Lock Y position", () => locks.LockPosY, x => locks.LockPosY = x);
+                ForEdit("Lock Z position", () => locks.LockPosZ, x => locks.LockPosZ = x);
+            });
 
             return true;
         }

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
@@ -46,6 +46,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
 
             ForHeader("Camera Locks", () =>
             {
+                ForEdit("Follow root bone", () => locks.FollowRootBone, x => locks.FollowRootBone = x);
                 ForEdit("Lock X rotation", () => locks.LockRotX, x => locks.LockRotX = x);
                 ForEdit("Lock Y rotation", () => locks.LockRotY, x => locks.LockRotY = x);
                 ForEdit("Lock Z rotation", () => locks.LockRotZ, x => locks.LockRotZ = x);

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
@@ -32,9 +32,12 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
                 camera.CameraRotationYawPitchRoll = new Vector3(-rotVec.X, rotBefore.Y, -rotVec.Y);
 
             var posAfter = camera.CameraPosition;
-            if (locks.LockPosX && !posChanged) posAfter.X = posBefore.X;
-            if (locks.LockPosY && !posChanged) posAfter.Y = posBefore.Y;
-            if (locks.LockPosZ && !posChanged) posAfter.Z = posBefore.Z;
+            if (locks.LockPosX && !(posChanged && posVec.X != posBefore.X))
+                posAfter.X = posBefore.X;
+            if (locks.LockPosY && !(posChanged && posVec.Y != posBefore.Y))
+                posAfter.Y = posBefore.Y;
+            if (locks.LockPosZ && !(posChanged && posVec.Z != posBefore.Z))
+                posAfter.Z = posBefore.Z;
             camera.CameraPosition = posAfter;
 
             var rotAfter = camera.CameraRotationYawPitchRoll;

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
@@ -19,22 +19,27 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
             ForEdit("Lock Z position", () => locks.LockPosZ, x => locks.LockPosZ = x);
 
             var posBefore = camera.CameraPosition;
-            ForEdit3("Position", () => camera.CameraPosition, x => camera.CameraPosition = x);
             var rotBefore = camera.CameraRotationYawPitchRoll;
-            ForEdit2("Rotation",
-                () => new Vector2(-camera.CameraRotationYawPitchRoll.X, -camera.CameraRotationYawPitchRoll.Z),
-                x => camera.CameraRotationYawPitchRoll = new Vector3(
-                    -x.X, camera.CameraRotationYawPitchRoll.Y, -x.Y));
+
+            var posVec = new Vector3(posBefore.X, posBefore.Y, posBefore.Z);
+            var posChanged = ImGui.DragFloat3("Position", ref posVec, 1.0f);
+            if (posChanged)
+                camera.CameraPosition = posVec;
+
+            var rotVec = new Vector2(-rotBefore.X, -rotBefore.Z);
+            var rotChanged = ImGui.DragFloat2("Rotation", ref rotVec, 1.0f);
+            if (rotChanged)
+                camera.CameraRotationYawPitchRoll = new Vector3(-rotVec.X, rotBefore.Y, -rotVec.Y);
 
             var posAfter = camera.CameraPosition;
-            if (locks.LockPosX) posAfter.X = posBefore.X;
-            if (locks.LockPosY) posAfter.Y = posBefore.Y;
-            if (locks.LockPosZ) posAfter.Z = posBefore.Z;
+            if (locks.LockPosX && !posChanged) posAfter.X = posBefore.X;
+            if (locks.LockPosY && !posChanged) posAfter.Y = posBefore.Y;
+            if (locks.LockPosZ && !posChanged) posAfter.Z = posBefore.Z;
             camera.CameraPosition = posAfter;
 
             var rotAfter = camera.CameraRotationYawPitchRoll;
-            if (locks.LockRotX) rotAfter.X = rotBefore.X;
-            if (locks.LockRotZ) rotAfter.Z = rotBefore.Z;
+            if (locks.LockRotX && !(rotChanged && rotVec.X != -rotBefore.X)) rotAfter.X = rotBefore.X;
+            if (locks.LockRotZ && !(rotChanged && rotVec.Y != -rotBefore.Z)) rotAfter.Z = rotBefore.Z;
             camera.CameraRotationYawPitchRoll = rotAfter;
         });
     }

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/CameraWindow.cs
@@ -1,4 +1,6 @@
+using ImGuiNET;
 using OpenKh.Engine;
+using OpenKh.Tools.Kh2MsetMotionEditor.Helpers;
 using System.Numerics;
 using static OpenKh.Tools.Common.CustomImGui.ImGuiEx;
 
@@ -6,13 +8,34 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
 {
     static class CameraWindow
     {
-        public static bool Run(Camera camera) => ForHeader("Camera", () =>
+        public static bool Run(Camera camera) => Run(camera, new CameraLockOptions());
+
+        public static bool Run(Camera camera, CameraLockOptions locks) => ForHeader("Camera", () =>
         {
+            ForEdit("Lock X rotation", () => locks.LockRotX, x => locks.LockRotX = x);
+            ForEdit("Lock Y rotation", () => locks.LockRotY, x => locks.LockRotY = x);
+            ForEdit("Lock X position", () => locks.LockPosX, x => locks.LockPosX = x);
+            ForEdit("Lock Y position", () => locks.LockPosY, x => locks.LockPosY = x);
+            ForEdit("Lock Z position", () => locks.LockPosZ, x => locks.LockPosZ = x);
+
+            var posBefore = camera.CameraPosition;
             ForEdit3("Position", () => camera.CameraPosition, x => camera.CameraPosition = x);
+            var rotBefore = camera.CameraRotationYawPitchRoll;
             ForEdit2("Rotation",
                 () => new Vector2(-camera.CameraRotationYawPitchRoll.X, -camera.CameraRotationYawPitchRoll.Z),
                 x => camera.CameraRotationYawPitchRoll = new Vector3(
                     -x.X, camera.CameraRotationYawPitchRoll.Y, -x.Y));
+
+            var posAfter = camera.CameraPosition;
+            if (locks.LockPosX) posAfter.X = posBefore.X;
+            if (locks.LockPosY) posAfter.Y = posBefore.Y;
+            if (locks.LockPosZ) posAfter.Z = posBefore.Z;
+            camera.CameraPosition = posAfter;
+
+            var rotAfter = camera.CameraRotationYawPitchRoll;
+            if (locks.LockRotX) rotAfter.X = rotBefore.X;
+            if (locks.LockRotY) rotAfter.Y = rotBefore.Y;
+            camera.CameraRotationYawPitchRoll = rotAfter;
         });
     }
 }


### PR DESCRIPTION
## Summary
- make camera tool a separate window with new lock options
- store camera lock settings and respect them when updating

## Testing
- `dotnet restore` *(fails: NETSDK1100)*

------
https://chatgpt.com/codex/tasks/task_e_687e775284ec83298417957d603e6602