### PR TITLE
Add Actions window

### DIFF
--- a/OpenKh.Tools.Kh2MsetMotionEditor/App.config
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/App.config
@@ -88,6 +88,9 @@
             <setting name="ViewFCurvesGrid" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="ViewActions" serializeAs="String">
+                <value>False</value>
+            </setting>
         </OpenKh.Tools.Kh2MsetMotionEditor.Settings>
     </userSettings>
 </configuration>

--- a/OpenKh.Tools.Kh2MsetMotionEditor/App.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/App.cs
@@ -264,6 +264,11 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor
                         _settings.ViewFCurveKey = it;
                         _settings.Save();
                     });
+                    ForMenuCheck("Actions", () => _settings.ViewActions, it =>
+                    {
+                        _settings.ViewActions = it;
+                        _settings.Save();
+                    });
                     ForMenuCheck("RootPosition", () => _settings.ViewRootPosition, it =>
                     {
                         _settings.ViewRootPosition = it;

--- a/OpenKh.Tools.Kh2MsetMotionEditor/DependencyInjection/UseExtensions.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/DependencyInjection/UseExtensions.cs
@@ -120,6 +120,7 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.DependencyInjection
             self.AddSingleton<IWindowRunnableProvider, FCurvesFkIkGridManagerWindow>();
             self.AddSingleton<IWindowRunnableProvider, NormalMessagesWindowUsecase>();
             self.AddSingleton<IWindowRunnableProvider, CameraWindowUsecase>();
+            self.AddSingleton<IWindowRunnableProvider, ActionsWindowUsecase>();
 
 
 

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Settings.Designer.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Settings.Designer.cs
@@ -346,5 +346,17 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor {
                 this["ViewFCurvesGrid"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ViewActions {
+            get {
+                return ((bool)(this["ViewActions"]));
+            }
+            set {
+                this["ViewActions"] = value;
+            }
+        }
     }
 }

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Settings.settings
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Settings.settings
@@ -80,8 +80,11 @@
     <Setting Name="ViewRootPosition" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="ViewFCurvesGrid" Type="System.Boolean" Scope="User">
+  <Setting Name="ViewFCurvesGrid" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
-    </Setting>
+  </Setting>
+  <Setting Name="ViewActions" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+  </Setting>
   </Settings>
 </SettingsFile>

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/ImGuiWindows/ActionsWindowUsecase.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/ImGuiWindows/ActionsWindowUsecase.cs
@@ -1,0 +1,36 @@
+using OpenKh.Tools.Kh2MsetMotionEditor.Helpers;
+using OpenKh.Tools.Kh2MsetMotionEditor.Interfaces;
+using OpenKh.Tools.Kh2MsetMotionEditor.Windows;
+using System;
+using static OpenKh.Tools.Common.CustomImGui.ImGuiEx;
+
+namespace OpenKh.Tools.Kh2MsetMotionEditor.Usecases.ImGuiWindows
+{
+    public class ActionsWindowUsecase : IWindowRunnableProvider
+    {
+        private readonly Settings _settings;
+        private readonly CameraLockOptions _locks;
+
+        public ActionsWindowUsecase(Settings settings, CameraLockOptions locks)
+        {
+            _settings = settings;
+            _locks = locks;
+        }
+
+        public Action CreateWindowRunnable()
+        {
+            return () =>
+            {
+                if (_settings.ViewActions)
+                {
+                    var closed = !ForWindow("Actions", () => ActionsWindow.Run(_locks));
+                    if (closed)
+                    {
+                        _settings.ViewActions = false;
+                        _settings.Save();
+                    }
+                }
+            };
+        }
+    }
+}

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/InsideTools/MotionPlayerToolUsecase.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Usecases/InsideTools/MotionPlayerToolUsecase.cs
@@ -114,6 +114,11 @@ namespace OpenKh.Tools.Kh2MsetMotionEditor.Usecases.InsideTools
                 {
                     _settings.ViewCamera = true;
                 }
+                ImGui.SameLine();
+                if (ImGui.Button("Actions"))
+                {
+                    _settings.ViewActions = true;
+                }
 
                 if (saved)
                 {

--- a/OpenKh.Tools.Kh2MsetMotionEditor/Windows/ActionsWindow.cs
+++ b/OpenKh.Tools.Kh2MsetMotionEditor/Windows/ActionsWindow.cs
@@ -1,0 +1,18 @@
+using OpenKh.Tools.Kh2MsetMotionEditor.Helpers;
+using static OpenKh.Tools.Common.CustomImGui.ImGuiEx;
+
+namespace OpenKh.Tools.Kh2MsetMotionEditor.Windows
+{
+    static class ActionsWindow
+    {
+        public static bool Run(CameraLockOptions locks)
+        {
+            ForHeader("Actions", () =>
+            {
+                ForEdit("Follow root bone", () => locks.FollowRootBone, x => locks.FollowRootBone = x);
+            });
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an Actions window for KH2 Mset motion editor
- register the window and expose it from menus
- link Follow root bone option to the new window

## Testing
- `dotnet build OpenKh.Tools.Kh2MsetMotionEditor/OpenKh.Tools.Kh2MsetMotionEditor.csproj -c Release` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_687fc82bba5883298c5ec7d36158d321