### PR TITLE
Add teleport button for spawn entities

### DIFF
--- a/OpenKh.Tools.BbsMapStudio/Interfaces/ISpawnPointController.cs
+++ b/OpenKh.Tools.BbsMapStudio/Interfaces/ISpawnPointController.cs
@@ -1,5 +1,6 @@
 using OpenKh.Tools.BbsMapStudio.Models;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace OpenKh.Tools.BbsMapStudio.Interfaces
 {
@@ -8,5 +9,6 @@ namespace OpenKh.Tools.BbsMapStudio.Interfaces
         List<SpawnPointModel> SpawnPoints { get; }
         SpawnPointModel CurrentSpawnPoint { get; }
         string SelectSpawnPoint { get; set; }
+        void TeleportCameraTo(Vector3 position);
     }
 }

--- a/OpenKh.Tools.BbsMapStudio/MapRenderer.cs
+++ b/OpenKh.Tools.BbsMapStudio/MapRenderer.cs
@@ -102,6 +102,11 @@ namespace OpenKh.Tools.BbsMapStudio
             set => CurrentSpawnPoint = SpawnPoints.FirstOrDefault(x => x.Name == value);
         }
 
+        public void TeleportCameraTo(Vector3 position)
+        {
+            Camera.CameraPosition = position;
+        }
+
         public SpawnScriptModel SpawnScriptMap { get; private set; }
         public SpawnScriptModel SpawnScriptBattle { get; private set; }
         public SpawnScriptModel SpawnScriptEvent { get; private set; }

--- a/OpenKh.Tools.BbsMapStudio/Windows/SpawnPointWindow.cs
+++ b/OpenKh.Tools.BbsMapStudio/Windows/SpawnPointWindow.cs
@@ -80,6 +80,11 @@ namespace OpenKh.Tools.BbsMapStudio.Windows
 
         private static void Run(SpawnPoint.Entity entity, int index)
         {
+            if (ImGui.Button($"Teleport to Entity##{index}"))
+            {
+                _ctrl.TeleportCameraTo(new Vector3(entity.PositionX, entity.PositionY, entity.PositionZ));
+            }
+
             var objs = _ctrl.CurrentSpawnPoint.ObjEntryCtrl;
             if (ImGui.BeginCombo($"Object##{index}", objs.GetName(entity.ObjectId)))
             {

--- a/OpenKh.Tools.Kh2MapStudio/Interfaces/ISpawnPointController.cs
+++ b/OpenKh.Tools.Kh2MapStudio/Interfaces/ISpawnPointController.cs
@@ -1,5 +1,6 @@
 using OpenKh.Tools.Kh2MapStudio.Models;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace OpenKh.Tools.Kh2MapStudio.Interfaces
 {
@@ -8,5 +9,6 @@ namespace OpenKh.Tools.Kh2MapStudio.Interfaces
         List<SpawnPointModel> SpawnPoints { get; }
         SpawnPointModel CurrentSpawnPoint { get; }
         string SelectSpawnPoint { get; set; }
+        void TeleportCameraTo(Vector3 position);
     }
 }

--- a/OpenKh.Tools.Kh2MapStudio/MapRenderer.cs
+++ b/OpenKh.Tools.Kh2MapStudio/MapRenderer.cs
@@ -120,6 +120,16 @@ namespace OpenKh.Tools.Kh2MapStudio
             set => CurrentSpawnPoint = SpawnPoints.FirstOrDefault(x => x.Name == value);
         }
 
+        public void TeleportCameraTo(Vector3 position)
+        {
+            Camera.CameraPosition = position;
+
+            if (MapCollision?.Coct is Coct coct)
+            {
+                CurrentArea.AreaSettingsMask = LocateCurrentArea(coct, Camera.CameraPosition);
+            }
+        }
+
         public SpawnScriptModel SpawnScriptMap { get; private set; }
         public SpawnScriptModel SpawnScriptBattle { get; private set; }
         public SpawnScriptModel SpawnScriptEvent { get; private set; }

--- a/OpenKh.Tools.Kh2MapStudio/Windows/SpawnPointWindow.cs
+++ b/OpenKh.Tools.Kh2MapStudio/Windows/SpawnPointWindow.cs
@@ -330,6 +330,11 @@ namespace OpenKh.Tools.Kh2MapStudio.Windows
 
         private static void Run(SpawnPoint.Entity entity, int index)
         {
+            if (ImGui.Button($"Teleport to Entity##{index}"))
+            {
+                _ctrl.TeleportCameraTo(new Vector3(entity.PositionX, entity.PositionY, entity.PositionZ));
+            }
+
             var objs = _ctrl.CurrentSpawnPoint.ObjEntryCtrl;
             if (ImGui.BeginCombo($"Object##{index}", objs.GetName(entity.ObjectId)))
             {


### PR DESCRIPTION
## Summary
- add a camera teleport method to spawn point controllers for both Map Studio tools
- add a "Teleport to Entity" button in the spawn group inspector to move the camera to the entity position

## Testing
- `dotnet build OpenKh.Tools.Kh2MapStudio/OpenKh.Tools.Kh2MapStudio.csproj` *(fails: dotnet not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cad2ad89088329bc73f23f4df4192f