### PR TITLE
Adjust mass export program file naming

### DIFF
--- a/OpenKh.Tools.Kh2MapStudio/App.cs
+++ b/OpenKh.Tools.Kh2MapStudio/App.cs
@@ -8,6 +8,7 @@ using OpenKh.Tools.Common.CustomImGui;
 using OpenKh.Tools.Kh2MapStudio.Windows;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -555,9 +556,10 @@ namespace OpenKh.Tools.Kh2MapStudio
                             foreach (var script in scripts)
                             {
                                 var programText = AreaDataScript.Decompile(new[] { script });
+                                var programIdDecimal = ((ushort)script.ProgramId).ToString(CultureInfo.InvariantCulture);
                                 var programFileName = Path.Combine(
                                     mapDirectory,
-                                    $"{programType}_program-{script.ProgramId:X2}.areadataprogram");
+                                    $"{programType}_{programIdDecimal}.areadataprogram");
                                 File.WriteAllText(programFileName, programText);
                                 exportedPrograms++;
                             }


### PR DESCRIPTION
## Summary
- update mass export file names to drop the redundant "program" label
- output AreaData program identifiers in decimal format for exported files

## Testing
- `dotnet build OpenKh.Tools.Kh2MapStudio/OpenKh.Tools.Kh2MapStudio.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb33996008329a06b6793392432f0