### PR TITLE
Add fulbright lighting and busy indicator to Spawn Point Explorer

### DIFF
--- a/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
@@ -8,6 +8,7 @@
         mc:Ignorable="d"
         Title="Spawn Point Explorer" Height="720" Width="1200" MinWidth="900" MinHeight="600">
     <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <HierarchicalDataTemplate DataType="{x:Type local:MapNodeViewModel}" ItemsSource="{Binding SpawnGroups}">
             <TextBlock Text="{Binding DisplayName}" />
         </HierarchicalDataTemplate>
@@ -95,5 +96,16 @@
         <StatusBar Grid.Row="2">
             <StatusBarItem Content="{Binding StatusMessage}" />
         </StatusBar>
+
+        <Border Grid.RowSpan="3"
+                Background="#99000000"
+                Visibility="{Binding IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}"
+                Panel.ZIndex="1"
+                IsHitTestVisible="True">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Margin="20">
+                <TextBlock Text="{Binding StatusMessage}" Foreground="White" FontSize="16" HorizontalAlignment="Center" />
+                <ProgressBar Width="240" IsIndeterminate="True" Margin="0,12,0,0" />
+            </StackPanel>
+        </Border>
     </Grid>
 </Window>

--- a/OpenKh.Command.SpawnPointExplorer/MdlxPreviewBuilder.cs
+++ b/OpenKh.Command.SpawnPointExplorer/MdlxPreviewBuilder.cs
@@ -124,6 +124,8 @@ internal static class MdlxPreviewBuilder
 
     private static Material CreateMaterial(ModelSkeletal.SkeletalGroup group, ModelTexture? texture)
     {
+        Brush? brush = null;
+
         if (texture != null)
         {
             try
@@ -132,14 +134,10 @@ internal static class MdlxPreviewBuilder
                 if (textureIndex >= 0 && textureIndex < texture.Images.Count)
                 {
                     var image = texture.Images[textureIndex].GetBimapSource();
-                    var brush = new ImageBrush(image)
+                    brush = new ImageBrush(image)
                     {
                         Stretch = Stretch.Uniform
                     };
-                    brush.Freeze();
-                    var material = new DiffuseMaterial(brush);
-                    material.Freeze();
-                    return material;
                 }
             }
             catch
@@ -148,11 +146,20 @@ internal static class MdlxPreviewBuilder
             }
         }
 
-        var solid = new SolidColorBrush(Color.FromRgb(200, 200, 200));
-        solid.Freeze();
-        var fallback = new DiffuseMaterial(solid);
-        fallback.Freeze();
-        return fallback;
+        brush ??= new SolidColorBrush(Color.FromRgb(200, 200, 200));
+        brush.Freeze();
+
+        var diffuse = new DiffuseMaterial(brush);
+        diffuse.Freeze();
+
+        var emissive = new EmissiveMaterial(brush);
+        emissive.Freeze();
+
+        var materialGroup = new MaterialGroup();
+        materialGroup.Children.Add(diffuse);
+        materialGroup.Children.Add(emissive);
+        materialGroup.Freeze();
+        return materialGroup;
     }
 }
 


### PR DESCRIPTION
## Summary
- render MDLX previews with emissive materials so they appear lit
- surface an overlay with a progress indicator while spawn data is loading

## Testing
- `dotnet build OpenKh.Command.SpawnPointExplorer/OpenKh.Command.SpawnPointExplorer.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d156342d24832999498e1c76fcf885