### PR TITLE
Group spawn occurrences by region with region-level exports

### DIFF
--- a/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
@@ -22,6 +22,8 @@
             <TextBlock Text="{Binding DisplayName}" />
         </DataTemplate>
         <Style TargetType="TreeViewItem">
+            <Setter Property="Tag" Value="{Binding DataContext.ExportSelectionCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+            <EventSetter Event="PreviewMouseRightButtonDown" Handler="OnTreeViewItemPreviewMouseRightButtonDown" />
             <Setter Property="ContextMenu">
                 <Setter.Value>
                     <ContextMenu>

--- a/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
@@ -9,6 +9,9 @@
         Title="Spawn Point Explorer" Height="720" Width="1200" MinWidth="900" MinHeight="600">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <HierarchicalDataTemplate DataType="{x:Type local:RegionNodeViewModel}" ItemsSource="{Binding Maps}">
+            <TextBlock Text="{Binding DisplayName}" />
+        </HierarchicalDataTemplate>
         <HierarchicalDataTemplate DataType="{x:Type local:MapNodeViewModel}" ItemsSource="{Binding SpawnGroups}">
             <TextBlock Text="{Binding DisplayName}" />
         </HierarchicalDataTemplate>
@@ -52,7 +55,7 @@
 
             <Border Grid.Column="0" Margin="0,0,10,0" BorderBrush="#FF444444" BorderThickness="1" Padding="4">
                 <TreeView x:Name="OccurrencesTree"
-                          ItemsSource="{Binding OccurrenceMaps}"
+                          ItemsSource="{Binding OccurrenceRegions}"
                           SelectedItemChanged="OnTreeSelectedItemChanged"
                           Tag="{Binding ExportSelectionCommand}" />
             </Border>

--- a/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml.cs
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using Forms = System.Windows.Forms;
 
 namespace OpenKh.Command.SpawnPointExplorer;
@@ -40,6 +42,15 @@ public partial class MainWindow : Window
     private void OnTreeSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
     {
         _viewModel.SelectedTreeItem = e.NewValue;
+    }
+
+    private void OnTreeViewItemPreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is TreeViewItem item)
+        {
+            item.Focus();
+            item.IsSelected = true;
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- group spawn occurrences by region within the spawnpoint explorer tree view
- add region node view models and support exporting region-wide spawn data to YAML
- generalize export serialization to handle region, map, group, and point selections

## Testing
- dotnet build OpenKh.Command.SpawnPointExplorer/OpenKh.Command.SpawnPointExplorer.csproj *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a9b6d72483299189f0f6de0539fd