### PR TITLE
Fix Spawn Point Explorer preview lighting

### DIFF
--- a/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
@@ -4,7 +4,6 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:OpenKh.Command.SpawnPointExplorer"
-        xmlns:h="http://helix-toolkit.org/wpf"
         mc:Ignorable="d"
         Title="Spawn Point Explorer" Height="720" Width="1200" MinWidth="900" MinHeight="600">
     <Window.Resources>
@@ -81,10 +80,9 @@
                             <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <h:HelixViewport3D Grid.Row="0" x:Name="Viewport" ShowFrameRate="False">
-                            <h:DefaultLights />
-                            <ModelVisual3D Content="{Binding PreviewModel}" />
-                        </h:HelixViewport3D>
+                        <ContentControl Grid.Row="0"
+                                        Background="#FF000000"
+                                        Content="{Binding PreviewContent}" />
                         <TextBlock Grid.Row="1" Text="{Binding PreviewStatus}" Margin="6" TextWrapping="Wrap" />
                     </Grid>
                 </Border>

--- a/OpenKh.Command.SpawnPointExplorer/MainWindowViewModel.cs
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 using OpenKh.Kh2;
 using OpenKh.Kh2.Ard;
+using OpenKh.Command.SpawnPointExplorer.Views;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -10,6 +11,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media.Media3D;
 using YamlDotNet.Serialization;
@@ -31,7 +33,7 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged
     private string _previewStatus = "";
     private string _occurrenceSummary = "";
     private string _selectedCandidateDetails = "";
-    private Model3DGroup? _previewModel;
+    private UIElement? _previewContent;
     private bool _isBusy;
 
     public MainWindowViewModel()
@@ -89,10 +91,10 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged
         private set => SetProperty(ref _selectedCandidateDetails, value);
     }
 
-    public Model3DGroup? PreviewModel
+    public UIElement? PreviewContent
     {
-        get => _previewModel;
-        private set => SetProperty(ref _previewModel, value);
+        get => _previewContent;
+        private set => SetProperty(ref _previewContent, value);
     }
 
     public bool IsBusy
@@ -124,7 +126,7 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged
         SelectedCandidate = null;
         Candidates.Clear();
         OccurrenceMaps.Clear();
-        PreviewModel = null;
+        PreviewContent = null;
         PreviewStatus = string.Empty;
         OccurrenceSummary = string.Empty;
         SelectedCandidateDetails = string.Empty;
@@ -215,7 +217,7 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged
         if (_spawnData == null || candidate == null)
         {
             OccurrenceMaps.Clear();
-            PreviewModel = null;
+            PreviewContent = null;
             PreviewStatus = string.Empty;
             OccurrenceSummary = string.Empty;
             SelectedCandidateDetails = string.Empty;
@@ -243,7 +245,7 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged
         var modelPath = candidate.ModelPath;
         if (string.IsNullOrEmpty(modelPath))
         {
-            PreviewModel = null;
+            PreviewContent = null;
             PreviewStatus = string.IsNullOrEmpty(candidate.ModelName)
                 ? "The selected entry does not reference a model name in objentry."
                 : string.Format(CultureInfo.InvariantCulture, "Model '{0}' not found under kh2/obj.", candidate.ModelName);
@@ -257,7 +259,9 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        PreviewModel = preview.Model;
+        PreviewContent = preview.Meshes != null
+            ? new MdlxViewportControl(preview.Meshes.ToList())
+            : null;
         PreviewStatus = preview.StatusMessage;
     }
 

--- a/OpenKh.Command.SpawnPointExplorer/MainWindowViewModel.cs
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindowViewModel.cs
@@ -259,10 +259,24 @@ internal sealed class MainWindowViewModel : INotifyPropertyChanged
             return;
         }
 
-        PreviewContent = preview.Meshes != null
-            ? new MdlxViewportControl(preview.Meshes.ToList())
-            : null;
-        PreviewStatus = preview.StatusMessage;
+        if (preview.Meshes != null)
+        {
+            try
+            {
+                PreviewContent = new MdlxViewportControl(preview.Meshes.ToList());
+                PreviewStatus = preview.StatusMessage;
+            }
+            catch (Exception ex)
+            {
+                PreviewContent = null;
+                PreviewStatus = "Failed to display model preview: " + ex.Message;
+            }
+        }
+        else
+        {
+            PreviewContent = null;
+            PreviewStatus = preview.StatusMessage;
+        }
     }
 
     private static string GetAbsolutePath(string path)

--- a/OpenKh.Command.SpawnPointExplorer/MdlxPreviewBuilder.cs
+++ b/OpenKh.Command.SpawnPointExplorer/MdlxPreviewBuilder.cs
@@ -152,14 +152,7 @@ internal static class MdlxPreviewBuilder
         var diffuse = new DiffuseMaterial(brush);
         diffuse.Freeze();
 
-        var emissive = new EmissiveMaterial(brush);
-        emissive.Freeze();
-
-        var materialGroup = new MaterialGroup();
-        materialGroup.Children.Add(diffuse);
-        materialGroup.Children.Add(emissive);
-        materialGroup.Freeze();
-        return materialGroup;
+        return diffuse;
     }
 }
 

--- a/OpenKh.Command.SpawnPointExplorer/MdlxPreviewBuilder.cs
+++ b/OpenKh.Command.SpawnPointExplorer/MdlxPreviewBuilder.cs
@@ -1,12 +1,11 @@
+using OpenKh.Command.SpawnPointExplorer.Utils;
 using OpenKh.Kh2;
 using OpenKh.Kh2.Models;
-using OpenKh.Tools.Common.Wpf;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Windows;
-using System.Windows.Media;
 using System.Windows.Media.Media3D;
 
 namespace OpenKh.Command.SpawnPointExplorer;
@@ -51,194 +50,31 @@ internal static class MdlxPreviewBuilder
                 return MdlxPreviewResult.Fail("The MDLX does not contain model data.");
             }
 
-            var group = new Model3DGroup();
-            foreach (var skeletalGroup in model.Groups)
-            {
-                var geometry = CreateMesh(skeletalGroup);
-                var material = CreateMaterial(skeletalGroup, texture);
-                var model3D = new GeometryModel3D(geometry, material)
-                {
-                    BackMaterial = material
-                };
-                model3D.Freeze();
-                group.Children.Add(model3D);
-            }
-
-            if (!group.Children.Any())
+            model.recalculateMeshes();
+            var meshes = Viewport3DUtils.getGeometryFromModel(model, texture);
+            if (!meshes.Any())
             {
                 return MdlxPreviewResult.Fail("The MDLX did not produce any renderable geometry.");
             }
 
-            group.Freeze();
             var status = string.Format(
-                System.Globalization.CultureInfo.InvariantCulture,
+                CultureInfo.InvariantCulture,
                 "{0} • {1} mesh(es)",
                 Path.GetFileName(path),
-                group.Children.Count);
-            return MdlxPreviewResult.Success(group, status);
+                meshes.Count);
+
+            return MdlxPreviewResult.Success(meshes, status);
         }
         catch (Exception ex)
         {
             return MdlxPreviewResult.Fail(ex.Message);
         }
     }
-
-    private static MeshGeometry3D CreateMesh(ModelSkeletal.SkeletalGroup group)
-    {
-        var vertexCount = group.Mesh.Vertices.Count;
-        var positions = new Point3D[vertexCount];
-        var normals = new Vector3D[vertexCount];
-        var hasNormals = new bool[vertexCount];
-        var textureCoordinates = new Point[vertexCount];
-
-        for (var index = 0; index < vertexCount; index++)
-        {
-            var vertex = group.Mesh.Vertices[index];
-            positions[index] = new Point3D(vertex.Position.X, vertex.Position.Y, vertex.Position.Z);
-            textureCoordinates[index] = new Point(vertex.U / 4096.0f, vertex.V / 4096.0f);
-
-            if (vertex.Normal == null)
-            {
-                continue;
-            }
-
-            var normal = new Vector3D(vertex.Normal.X, vertex.Normal.Y, vertex.Normal.Z);
-            if (normal.LengthSquared <= double.Epsilon)
-            {
-                continue;
-            }
-
-            normal.Normalize();
-            normals[index] = normal;
-            hasNormals[index] = true;
-        }
-
-        var triangleIndexList = new List<int>(group.Mesh.Triangles.Sum(triangle => triangle.Count));
-        foreach (var triangle in group.Mesh.Triangles)
-        {
-            foreach (var vertexIndex in triangle)
-            {
-                triangleIndexList.Add(vertexIndex);
-            }
-        }
-
-        if (hasNormals.Any(hasNormal => !hasNormal))
-        {
-            var computedNormals = new Vector3D[vertexCount];
-            var fallbackNormals = new Vector3D[vertexCount];
-            var hasFallbackNormal = new bool[vertexCount];
-
-            for (var i = 0; i <= triangleIndexList.Count - 3; i += 3)
-            {
-                var i0 = triangleIndexList[i];
-                var i1 = triangleIndexList[i + 1];
-                var i2 = triangleIndexList[i + 2];
-
-                if (i0 < 0 || i0 >= vertexCount ||
-                    i1 < 0 || i1 >= vertexCount ||
-                    i2 < 0 || i2 >= vertexCount)
-                {
-                    continue;
-                }
-
-                var p0 = positions[i0];
-                var p1 = positions[i1];
-                var p2 = positions[i2];
-
-                var edge1 = p1 - p0;
-                var edge2 = p2 - p0;
-                var faceNormal = Vector3D.CrossProduct(edge1, edge2);
-
-                if (faceNormal.LengthSquared <= double.Epsilon)
-                {
-                    continue;
-                }
-
-                faceNormal.Normalize();
-                computedNormals[i0] += faceNormal;
-                computedNormals[i1] += faceNormal;
-                computedNormals[i2] += faceNormal;
-
-                fallbackNormals[i0] = faceNormal;
-                fallbackNormals[i1] = faceNormal;
-                fallbackNormals[i2] = faceNormal;
-                hasFallbackNormal[i0] = true;
-                hasFallbackNormal[i1] = true;
-                hasFallbackNormal[i2] = true;
-            }
-
-            for (var index = 0; index < vertexCount; index++)
-            {
-                if (hasNormals[index])
-                {
-                    continue;
-                }
-
-                var normal = computedNormals[index];
-                if (normal.LengthSquared <= double.Epsilon)
-                {
-                    if (!hasFallbackNormal[index])
-                    {
-                        continue;
-                    }
-
-                    normal = fallbackNormals[index];
-                }
-
-                normal.Normalize();
-                normals[index] = normal;
-            }
-        }
-
-        var geometry = new MeshGeometry3D
-        {
-            Positions = new Point3DCollection(positions),
-            Normals = new Vector3DCollection(normals),
-            TextureCoordinates = new PointCollection(textureCoordinates),
-            TriangleIndices = new Int32Collection(triangleIndexList)
-        };
-
-        geometry.Freeze();
-        return geometry;
-    }
-
-    private static Material CreateMaterial(ModelSkeletal.SkeletalGroup group, ModelTexture? texture)
-    {
-        Brush? brush = null;
-
-        if (texture != null)
-        {
-            try
-            {
-                var textureIndex = (int)group.Header.TextureIndex;
-                if (textureIndex >= 0 && textureIndex < texture.Images.Count)
-                {
-                    var image = texture.Images[textureIndex].GetBimapSource();
-                    brush = new ImageBrush(image)
-                    {
-                        Stretch = Stretch.Uniform
-                    };
-                }
-            }
-            catch
-            {
-                // Fallback to solid color below.
-            }
-        }
-
-        brush ??= new SolidColorBrush(Color.FromRgb(200, 200, 200));
-        brush.Freeze();
-
-        var diffuse = new DiffuseMaterial(brush);
-        diffuse.Freeze();
-
-        return diffuse;
-    }
 }
 
-internal sealed record MdlxPreviewResult(Model3DGroup? Model, string StatusMessage)
+internal sealed record MdlxPreviewResult(IReadOnlyList<GeometryModel3D>? Meshes, string StatusMessage)
 {
-    public static MdlxPreviewResult Success(Model3DGroup model, string status) => new(model, status);
+    public static MdlxPreviewResult Success(IReadOnlyList<GeometryModel3D> meshes, string status) => new(meshes, status);
 
     public static MdlxPreviewResult Fail(string message) => new(null, message);
 }

--- a/OpenKh.Command.SpawnPointExplorer/MdlxPreviewBuilder.cs
+++ b/OpenKh.Command.SpawnPointExplorer/MdlxPreviewBuilder.cs
@@ -125,6 +125,9 @@ internal static class MdlxPreviewBuilder
         if (hasNormals.Any(hasNormal => !hasNormal))
         {
             var computedNormals = new Vector3D[vertexCount];
+            var fallbackNormals = new Vector3D[vertexCount];
+            var hasFallbackNormal = new bool[vertexCount];
+
             for (var i = 0; i <= triangleIndexList.Count - 3; i += 3)
             {
                 var i0 = triangleIndexList[i];
@@ -155,6 +158,13 @@ internal static class MdlxPreviewBuilder
                 computedNormals[i0] += faceNormal;
                 computedNormals[i1] += faceNormal;
                 computedNormals[i2] += faceNormal;
+
+                fallbackNormals[i0] = faceNormal;
+                fallbackNormals[i1] = faceNormal;
+                fallbackNormals[i2] = faceNormal;
+                hasFallbackNormal[i0] = true;
+                hasFallbackNormal[i1] = true;
+                hasFallbackNormal[i2] = true;
             }
 
             for (var index = 0; index < vertexCount; index++)
@@ -167,7 +177,12 @@ internal static class MdlxPreviewBuilder
                 var normal = computedNormals[index];
                 if (normal.LengthSquared <= double.Epsilon)
                 {
-                    continue;
+                    if (!hasFallbackNormal[index])
+                    {
+                        continue;
+                    }
+
+                    normal = fallbackNormals[index];
                 }
 
                 normal.Normalize();

--- a/OpenKh.Command.SpawnPointExplorer/OpenKh.Command.SpawnPointExplorer.csproj
+++ b/OpenKh.Command.SpawnPointExplorer/OpenKh.Command.SpawnPointExplorer.csproj
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HelixToolkit.Wpf" Version="2.25.0" />
     <PackageReference Include="YamlDotNet" Version="15.3.0" />
   </ItemGroup>
 

--- a/OpenKh.Command.SpawnPointExplorer/Utils/Viewport3DUtils.cs
+++ b/OpenKh.Command.SpawnPointExplorer/Utils/Viewport3DUtils.cs
@@ -1,0 +1,247 @@
+using OpenKh.Kh2;
+using OpenKh.Kh2.Models;
+using OpenKh.Tools.Common.Wpf;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
+
+namespace OpenKh.Command.SpawnPointExplorer.Utils
+{
+    internal static class Viewport3DUtils
+    {
+        public static PerspectiveCamera getDefaultCamera(int distance = 500)
+        {
+            var camera = new PerspectiveCamera
+            {
+                Position = new Point3D(0, 0, distance),
+                LookDirection = new Vector3D(0, 0, -1),
+                FieldOfView = 60,
+            };
+
+            return camera;
+        }
+
+        public static PerspectiveCamera getCameraByBoundingBox(Rect3D boundingBox)
+        {
+            var maxSize = boundingBox.SizeX > boundingBox.SizeY ? boundingBox.SizeX : boundingBox.SizeY;
+            var camera = new PerspectiveCamera
+            {
+                Position = new Point3D(0, 0, maxSize * 1.2),
+                LookDirection = new Vector3D(0, 0, -1),
+                FieldOfView = 60,
+            };
+
+            return camera;
+        }
+
+        public static Vector3D getVectorToTarget(Point3D position, Point3D targetPosition = new())
+        {
+            var vector = new Vector3D(position.X, position.Y, position.Z);
+            var targetVector = new Vector3D(targetPosition.X, targetPosition.Y, targetPosition.Z);
+            return getVectorToTarget(vector, targetVector);
+        }
+
+        public static Vector3D getVectorToTarget(Vector3D position, Vector3D targetPosition = new())
+        {
+            return -(position - targetPosition);
+        }
+
+        public static GeometryModel3D getGeometryFromGroup(ModelSkeletal.SkeletalGroup group, ModelTexture? textureFile = null)
+        {
+            var geometryModel = new GeometryModel3D();
+            var meshGeometry = new MeshGeometry3D();
+
+            var positionCollection = new Point3DCollection();
+            foreach (var vertex in group.Mesh.Vertices)
+            {
+                positionCollection.Add(new Point3D(vertex.Position.X, vertex.Position.Y, vertex.Position.Z));
+            }
+            meshGeometry.Positions = positionCollection;
+
+            var textureCoordinatesCollection = new PointCollection();
+            foreach (var vertex in group.Mesh.Vertices)
+            {
+                textureCoordinatesCollection.Add(new Point(vertex.U / 4096.0f, vertex.V / 4096.0f));
+            }
+            meshGeometry.TextureCoordinates = textureCoordinatesCollection;
+
+            var triangleIndicesCollection = new Int32Collection();
+            foreach (var triangle in group.Mesh.Triangles)
+            {
+                foreach (var triangleVertex in triangle)
+                {
+                    triangleIndicesCollection.Add(triangleVertex);
+                }
+            }
+            meshGeometry.TriangleIndices = triangleIndicesCollection;
+
+            geometryModel.Geometry = meshGeometry;
+
+            DiffuseMaterial material;
+            try
+            {
+                var textureIndex = (int)group.Header.TextureIndex;
+                if (textureFile == null || textureFile.Images == null || textureFile.Images.Count < textureIndex)
+                {
+                    material = getDefaultMaterial();
+                }
+                else
+                {
+                    var texture = textureFile.Images[textureIndex];
+                    ImageSource imageSource = texture.GetBimapSource();
+                    material = new DiffuseMaterial(new ImageBrush(imageSource));
+                }
+            }
+            catch
+            {
+                material = getDefaultMaterial();
+            }
+
+            geometryModel.Material = material;
+
+            positionCollection.Add(new Point3D(0, 0, 0));
+            positionCollection.Add(new Point3D(0, 0, 0));
+            textureCoordinatesCollection.Add(new Point(0, 0));
+            textureCoordinatesCollection.Add(new Point(1, 1));
+
+            return geometryModel;
+        }
+
+        public static List<GeometryModel3D> getGeometryFromModel(ModelSkeletal modelFile, ModelTexture? textureFile = null)
+        {
+            var geometryList = new List<GeometryModel3D>();
+            foreach (var group in modelFile.Groups)
+            {
+                geometryList.Add(getGeometryFromGroup(group, textureFile));
+            }
+
+            return geometryList;
+        }
+
+        public static void addTri(Int32Collection triangleIndicesCollection, int i1, int i2, int i3)
+        {
+            triangleIndicesCollection.Add(i1);
+            triangleIndicesCollection.Add(i2);
+            triangleIndicesCollection.Add(i3);
+        }
+
+        public static GeometryModel3D getCube(int size, Vector3D position, Color color)
+        {
+            var cube = getCube(size, position);
+            cube.Material = new DiffuseMaterial(new SolidColorBrush(color));
+
+            return cube;
+        }
+
+        public static GeometryModel3D getCube(int size, Vector3D position = new())
+        {
+            var meshGeometry = new MeshGeometry3D();
+            var positionCollection = new Point3DCollection
+            {
+                new Point3D(position.X - size, position.Y - size, position.Z - size),
+                new Point3D(position.X + size, position.Y - size, position.Z - size),
+                new Point3D(position.X - size, position.Y + size, position.Z - size),
+                new Point3D(position.X + size, position.Y + size, position.Z - size),
+                new Point3D(position.X - size, position.Y - size, position.Z + size),
+                new Point3D(position.X + size, position.Y - size, position.Z + size),
+                new Point3D(position.X - size, position.Y + size, position.Z + size),
+                new Point3D(position.X + size, position.Y + size, position.Z + size),
+            };
+
+            meshGeometry.Positions = positionCollection;
+
+            var triangleIndicesCollection = new Int32Collection();
+
+            addTri(triangleIndicesCollection, 2, 3, 1);
+            addTri(triangleIndicesCollection, 2, 1, 0);
+            addTri(triangleIndicesCollection, 7, 1, 3);
+            addTri(triangleIndicesCollection, 7, 5, 1);
+            addTri(triangleIndicesCollection, 6, 5, 7);
+            addTri(triangleIndicesCollection, 6, 4, 5);
+            addTri(triangleIndicesCollection, 2, 4, 6);
+            addTri(triangleIndicesCollection, 2, 0, 4);
+            addTri(triangleIndicesCollection, 2, 7, 3);
+            addTri(triangleIndicesCollection, 2, 6, 7);
+            addTri(triangleIndicesCollection, 0, 1, 5);
+            addTri(triangleIndicesCollection, 0, 5, 4);
+
+            meshGeometry.TriangleIndices = triangleIndicesCollection;
+
+            var geometryModel = new GeometryModel3D
+            {
+                Geometry = meshGeometry,
+                Material = new DiffuseMaterial(new SolidColorBrush(Color.FromArgb(40, 255, 0, 0))),
+            };
+
+            return geometryModel;
+        }
+
+        public static GeometryModel3D getCube(int radius, int height, Vector3D position, Color color)
+        {
+            var cube = getCube(radius, height, position);
+            cube.Material = new DiffuseMaterial(new SolidColorBrush(color));
+
+            return cube;
+        }
+
+        public static GeometryModel3D getCube(int radius, int height, Vector3D position = new())
+        {
+            var meshGeometry = new MeshGeometry3D();
+            var positionCollection = new Point3DCollection
+            {
+                new Point3D(position.X - radius, position.Y - height, position.Z - radius),
+                new Point3D(position.X + radius, position.Y - height, position.Z - radius),
+                new Point3D(position.X - radius, position.Y + height, position.Z - radius),
+                new Point3D(position.X + radius, position.Y + height, position.Z - radius),
+                new Point3D(position.X - radius, position.Y - height, position.Z + radius),
+                new Point3D(position.X + radius, position.Y - height, position.Z + radius),
+                new Point3D(position.X - radius, position.Y + height, position.Z + radius),
+                new Point3D(position.X + radius, position.Y + height, position.Z + radius),
+            };
+
+            meshGeometry.Positions = positionCollection;
+
+            var triangleIndicesCollection = new Int32Collection();
+
+            addTri(triangleIndicesCollection, 2, 3, 1);
+            addTri(triangleIndicesCollection, 2, 1, 0);
+            addTri(triangleIndicesCollection, 7, 1, 3);
+            addTri(triangleIndicesCollection, 7, 5, 1);
+            addTri(triangleIndicesCollection, 6, 5, 7);
+            addTri(triangleIndicesCollection, 6, 4, 5);
+            addTri(triangleIndicesCollection, 2, 4, 6);
+            addTri(triangleIndicesCollection, 2, 0, 4);
+            addTri(triangleIndicesCollection, 2, 7, 3);
+            addTri(triangleIndicesCollection, 2, 6, 7);
+            addTri(triangleIndicesCollection, 0, 1, 5);
+            addTri(triangleIndicesCollection, 0, 5, 4);
+
+            meshGeometry.TriangleIndices = triangleIndicesCollection;
+
+            var geometryModel = new GeometryModel3D
+            {
+                Geometry = meshGeometry,
+                Material = new DiffuseMaterial(new SolidColorBrush(Color.FromArgb(100, 255, 0, 0))),
+            };
+
+            return geometryModel;
+        }
+
+        public static DiffuseMaterial getDefaultMaterial()
+        {
+            var gradient = new LinearGradientBrush
+            {
+                StartPoint = new Point(0, 0.5),
+                EndPoint = new Point(1, 0.5),
+            };
+            gradient.GradientStops.Add(new GradientStop(Colors.Yellow, 0.0));
+            gradient.GradientStops.Add(new GradientStop(Colors.Red, 0.25));
+            gradient.GradientStops.Add(new GradientStop(Colors.Blue, 0.75));
+            gradient.GradientStops.Add(new GradientStop(Colors.LimeGreen, 1.0));
+
+            return new DiffuseMaterial(gradient);
+        }
+    }
+}

--- a/OpenKh.Command.SpawnPointExplorer/Views/MdlxViewportControl.xaml
+++ b/OpenKh.Command.SpawnPointExplorer/Views/MdlxViewportControl.xaml
@@ -1,0 +1,17 @@
+<UserControl x:Class="OpenKh.Command.SpawnPointExplorer.Views.MdlxViewportControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <Grid Background="Black"
+          MouseWheel="Viewport_MouseWheel"
+          MouseMove="Viewport_MouseMove"
+          MouseRightButtonDown="Viewport_MouseRightButtonDown"
+          MouseRightButtonUp="Viewport_MouseRightButtonUp">
+        <ContentControl x:Name="viewportFrame" />
+    </Grid>
+
+</UserControl>

--- a/OpenKh.Command.SpawnPointExplorer/Views/MdlxViewportControl.xaml.cs
+++ b/OpenKh.Command.SpawnPointExplorer/Views/MdlxViewportControl.xaml.cs
@@ -1,0 +1,243 @@
+using OpenKh.Command.SpawnPointExplorer.Utils;
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
+
+namespace OpenKh.Command.SpawnPointExplorer.Views
+{
+    public partial class MdlxViewportControl : UserControl
+    {
+        private static Point _leftPreviousPosition = new();
+        private static Point _leftCurrentPosition = new();
+        private static Point _rightPreviousPosition = new();
+        private static Point _rightCurrentPosition = new();
+
+        public Viewport3D Viewport { get; set; }
+        public PerspectiveCamera VPCamera { get; set; }
+        public List<GeometryModel3D> VPMeshes { get; set; }
+        public Point3D AnchorPoint { get; set; }
+        public Point3D AnchorPointTemp { get; set; }
+        public Vector3D AnchorPointHorVec { get; set; }
+        public Vector3D AnchorPointVerVec { get; set; }
+        public bool AnchorPointLocked { get; set; }
+
+        public MdlxViewportControl()
+        {
+            InitializeComponent();
+        }
+
+        public MdlxViewportControl(List<GeometryModel3D> vpMeshes, PerspectiveCamera? vpCamera = null)
+        {
+            InitializeComponent();
+            Viewport = new Viewport3D();
+            var boundingBox = getBoundingBox(vpMeshes);
+
+            VPCamera = vpCamera ?? Viewport3DUtils.getCameraByBoundingBox(boundingBox);
+            Viewport.Camera = VPCamera;
+            AnchorPoint = new Point3D();
+            AnchorPointTemp = new Point3D();
+            AnchorPointLocked = false;
+
+            var modelGroup = new Model3DGroup();
+            modelGroup.Children.Add(new AmbientLight(Brushes.White.Color));
+
+            VPMeshes = vpMeshes;
+            foreach (var mesh in VPMeshes)
+            {
+                modelGroup.Children.Add(mesh);
+            }
+
+            var visual = new ModelVisual3D { Content = modelGroup };
+            Viewport.Children.Add(visual);
+
+            viewportFrame.Content = Viewport;
+        }
+
+        private void Viewport_MouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            const double scale = 0.3;
+            var position = VPCamera.Position;
+            var lookVector = Viewport3DUtils.getVectorToTarget(VPCamera.Position, AnchorPoint);
+            var length = lookVector.Length;
+            lookVector.Normalize();
+
+            if (e.Delta > 0)
+            {
+                lookVector *= length * scale;
+            }
+            else if (e.Delta < 0)
+            {
+                lookVector *= length * (-scale);
+            }
+
+            VPCamera.Position = new Point3D(position.X + lookVector.X, position.Y + lookVector.Y, position.Z + lookVector.Z);
+        }
+
+        private void Viewport_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (e.RightButton == MouseButtonState.Pressed)
+            {
+                _rightCurrentPosition = e.GetPosition(viewportFrame);
+
+                if (_rightPreviousPosition != _rightCurrentPosition)
+                {
+                    moveCamera(_rightPreviousPosition, _rightCurrentPosition);
+                }
+            }
+            else if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                _leftCurrentPosition = e.GetPosition(viewportFrame);
+
+                if (_leftPreviousPosition != _leftCurrentPosition)
+                {
+                    rotateCamera(_leftCurrentPosition.X - _leftPreviousPosition.X, _leftCurrentPosition.Y - _leftPreviousPosition.Y, 0);
+                }
+            }
+
+            _rightPreviousPosition = e.GetPosition(viewportFrame);
+            _leftPreviousPosition = e.GetPosition(viewportFrame);
+        }
+
+        private void Viewport_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            AnchorPointLocked = true;
+            AnchorPointTemp = new Point3D(AnchorPoint.X, AnchorPoint.Y, AnchorPoint.Z);
+
+            var position = VPCamera.Position;
+            AnchorPointHorVec = getHorizontalPerpendicularVector(new Vector3D(position.X - AnchorPoint.X, position.Y - AnchorPoint.Y, position.Z - AnchorPoint.Z));
+            AnchorPointVerVec = getVerticalPerpendicularVector(new Vector3D(position.X - AnchorPoint.X, position.Y - AnchorPoint.Y, position.Z - AnchorPoint.Z), AnchorPointHorVec);
+        }
+
+        private void Viewport_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            AnchorPointLocked = false;
+            AnchorPoint = new Point3D(AnchorPointTemp.X, AnchorPointTemp.Y, AnchorPointTemp.Z);
+        }
+
+        public void moveCamera(Point pre, Point cur)
+        {
+            var position = VPCamera.Position;
+            var positionVector = new Vector3D(VPCamera.Position.X, VPCamera.Position.Y, VPCamera.Position.Z);
+            var speed = positionVector.Length / 600;
+
+            var moveHorVec = AnchorPointHorVec * (cur.X - pre.X) * speed;
+            var moveVerVec = AnchorPointVerVec * (cur.Y - pre.Y) * speed;
+
+            VPCamera.Position = new Point3D(position.X - moveHorVec.X, position.Y + moveVerVec.Y, position.Z - moveHorVec.Z);
+            AnchorPointTemp = new Point3D(AnchorPointTemp.X - moveHorVec.X, AnchorPointTemp.Y + moveVerVec.Y, AnchorPointTemp.Z - moveHorVec.Z);
+        }
+
+        public void rotateCamera(Point pre, Point cur)
+        {
+            var position = VPCamera.Position;
+            const double speed = 1;
+
+            VPCamera.Position = new Point3D(position.X - (cur.X - pre.X) * speed, position.Y + (cur.Y - pre.Y) * speed, position.Z);
+        }
+
+        private void rotateCamera(double rX, double rY, double rZ)
+        {
+            var vector = new Vector3D(VPCamera.Position.X - AnchorPoint.X, VPCamera.Position.Y - AnchorPoint.Y, VPCamera.Position.Z - AnchorPoint.Z);
+
+            var length = vector.Length;
+            var theta = Math.Acos(vector.Y / length);
+            var phi = Math.Atan2(-vector.Z, vector.X);
+
+            theta -= rY * 0.01;
+            phi -= rX * 0.01;
+            length *= 1.0 - 0.1 * rZ;
+
+            theta = Math.Clamp(theta, 0.0001, Math.PI - 0.0001);
+
+            vector.X = length * Math.Sin(theta) * Math.Cos(phi);
+            vector.Z = -length * Math.Sin(theta) * Math.Sin(phi);
+            vector.Y = length * Math.Cos(theta);
+
+            VPCamera.Position = new Point3D(AnchorPoint.X + vector.X, AnchorPoint.Y + vector.Y, AnchorPoint.Z + vector.Z);
+            VPCamera.LookDirection = Viewport3DUtils.getVectorToTarget(VPCamera.Position, AnchorPoint);
+        }
+
+        private Vector3D getHorizontalPerpendicularVector(Vector3D vector)
+        {
+            var perpendicularVector = new Vector3D(vector.Z, 0, -vector.X);
+            if (perpendicularVector.X != 0 || perpendicularVector.Y != 0 || perpendicularVector.Z != 0)
+            {
+                perpendicularVector.Normalize();
+            }
+
+            return perpendicularVector;
+        }
+
+        private Vector3D getVerticalPerpendicularVector(Vector3D cameraVector, Vector3D horizontalVector)
+        {
+            var perpendicularVector = Vector3D.CrossProduct(cameraVector, horizontalVector);
+            if (perpendicularVector.X != 0 || perpendicularVector.Y != 0 || perpendicularVector.Z != 0)
+            {
+                perpendicularVector.Normalize();
+            }
+
+            return perpendicularVector;
+        }
+
+        private Rect3D getBoundingBox(List<GeometryModel3D> vpMeshes)
+        {
+            var boundingBox = new Rect3D();
+            float minX = 0;
+            float maxX = 0;
+            float minY = 0;
+            float maxY = 0;
+            float minZ = 0;
+            float maxZ = 0;
+            foreach (var mesh in vpMeshes)
+            {
+                var localMinX = (float)(mesh.Geometry.Bounds.Location.X - mesh.Geometry.Bounds.SizeX);
+                var localMaxX = (float)(mesh.Geometry.Bounds.Location.X + mesh.Geometry.Bounds.SizeX);
+                var localMinY = (float)(mesh.Geometry.Bounds.Location.Y - mesh.Geometry.Bounds.SizeY);
+                var localMaxY = (float)(mesh.Geometry.Bounds.Location.Y + mesh.Geometry.Bounds.SizeY);
+                var localMinZ = (float)(mesh.Geometry.Bounds.Location.Z - mesh.Geometry.Bounds.SizeZ);
+                var localMaxZ = (float)(mesh.Geometry.Bounds.Location.Z + mesh.Geometry.Bounds.SizeZ);
+
+                if (localMinX < minX)
+                {
+                    minX = localMinX;
+                }
+                if (localMaxX > maxX)
+                {
+                    maxX = localMaxX;
+                }
+                if (localMinY < minY)
+                {
+                    minY = localMinY;
+                }
+                if (localMaxY > maxY)
+                {
+                    maxY = localMaxY;
+                }
+                if (localMinZ < minZ)
+                {
+                    minZ = localMinZ;
+                }
+                if (localMaxZ > maxZ)
+                {
+                    maxZ = localMaxZ;
+                }
+            }
+
+            boundingBox.SizeX = Math.Abs(maxX - minX);
+            boundingBox.SizeY = Math.Abs(maxY - minY);
+            boundingBox.SizeZ = Math.Abs(maxZ - minZ);
+
+            var X = minX + (boundingBox.SizeX / 2);
+            var Y = minY + (boundingBox.SizeY / 2);
+            var Z = minZ + (boundingBox.SizeZ / 2);
+
+            boundingBox.Location = new Point3D(X, Y, Z);
+
+            return boundingBox;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove the emissive material from Spawn Point Explorer meshes so the preview relies on diffuse lighting like the MDLX editor

## Testing
- `dotnet build OpenKh.Command.SpawnPointExplorer/OpenKh.Command.SpawnPointExplorer.csproj` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3dc177ec083299a3755076fad1c63