### PR TITLE
Group spawnpoint explorer results by region

### DIFF
--- a/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
@@ -8,6 +8,9 @@
         Title="Spawn Point Explorer" Height="720" Width="1200" MinWidth="900" MinHeight="600">
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <HierarchicalDataTemplate DataType="{x:Type local:RegionNodeViewModel}" ItemsSource="{Binding Maps}">
+            <TextBlock Text="{Binding DisplayName}" />
+        </HierarchicalDataTemplate>
         <HierarchicalDataTemplate DataType="{x:Type local:MapNodeViewModel}" ItemsSource="{Binding SpawnGroups}">
             <TextBlock Text="{Binding DisplayName}" />
         </HierarchicalDataTemplate>
@@ -51,7 +54,7 @@
 
             <Border Grid.Column="0" Margin="0,0,10,0" BorderBrush="#FF444444" BorderThickness="1" Padding="4">
                 <TreeView x:Name="OccurrencesTree"
-                          ItemsSource="{Binding OccurrenceMaps}"
+                          ItemsSource="{Binding OccurrenceRegions}"
                           SelectedItemChanged="OnTreeSelectedItemChanged"
                           Tag="{Binding ExportSelectionCommand}" />
             </Border>


### PR DESCRIPTION
## Summary
- group spawn search results under region nodes in the tree view
- add region view models and logic to build region groupings and export paths
- implement mass YAML export for a whole region that writes each spawn group into its map folder

## Testing
- `dotnet build OpenKh.Command.SpawnPointExplorer/OpenKh.Command.SpawnPointExplorer.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3efe8adf083299445f1db96d77aaf