### PR TITLE
Improve spawnpoint explorer loading workflow

### DIFF
--- a/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml
@@ -52,7 +52,7 @@
             <TextBlock Text="Data Root:" VerticalAlignment="Center" Margin="0,0,8,0" />
             <TextBox Width="420" Text="{Binding DataRoot, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,8,0" />
             <Button Content="Browse..." Click="OnBrowseClick" Margin="0,0,8,0" />
-            <Button Content="Load" Click="OnLoadClick" />
+            <Button Content="Refresh" Click="OnRefreshClick" />
         </StackPanel>
 
         <Grid Grid.Row="1" Margin="10">

--- a/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml.cs
+++ b/OpenKh.Command.SpawnPointExplorer/MainWindow.xaml.cs
@@ -14,7 +14,7 @@ public partial class MainWindow : Window
         DataContext = _viewModel;
     }
 
-    private void OnBrowseClick(object sender, RoutedEventArgs e)
+    private async void OnBrowseClick(object sender, RoutedEventArgs e)
     {
         using var dialog = new Forms.FolderBrowserDialog
         {
@@ -29,10 +29,11 @@ public partial class MainWindow : Window
         if (dialog.ShowDialog() == Forms.DialogResult.OK)
         {
             _viewModel.DataRoot = dialog.SelectedPath;
+            await _viewModel.LoadAsync();
         }
     }
 
-    private async void OnLoadClick(object sender, RoutedEventArgs e)
+    private async void OnRefreshClick(object sender, RoutedEventArgs e)
     {
         await _viewModel.LoadAsync();
     }


### PR DESCRIPTION
## Summary
- trigger the spawnpoint scan automatically after selecting a folder in the browse dialog
- replace the Load button with a Refresh action to rescan the data root on demand

## Testing
- dotnet build OpenKh.Command.SpawnPointExplorer/OpenKh.Command.SpawnPointExplorer.csproj *(fails: dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d41ff7840c8329b4199cb62bd58323