### PR TITLE
Enhance Mod Browser badges from repository metadata

### DIFF
--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -64,7 +64,7 @@
                                         </Grid.ColumnDefinitions>
                                         <Button Width="72"
                                                 Height="72"
-                                                Command="{Binding DataContext.CheckLanguagesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                Command="{Binding DataContext.LoadBadgesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                                                 CommandParameter="{Binding}"
                                                 Style="{StaticResource TransparentButtonStyle}">
                                             <Border Background="#2d2d2d" CornerRadius="4">
@@ -72,19 +72,35 @@
                                             </Border>
                                         </Button>
                                         <StackPanel Grid.Column="2" VerticalAlignment="Center">
-                                            <Button Command="{Binding DataContext.CheckLanguagesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                            <Button Command="{Binding DataContext.LoadBadgesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                                                     CommandParameter="{Binding}"
                                                     Style="{StaticResource TransparentButtonStyle}"
                                                     HorizontalAlignment="Left">
                                                 <TextBlock Text="{Binding Name}" FontSize="16" FontWeight="Bold" Foreground="White"/>
                                             </Button>
                                             <TextBlock Text="{Binding DisplayAuthor}" Foreground="#d0d0d0"/>
-                                            <StackPanel Orientation="Horizontal" Margin="0,4,0,0"
-                                                        Visibility="{Binding HasLua, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                                <Border Background="#2962ff" CornerRadius="4" Padding="6,2">
-                                                    <TextBlock Text="Lua" Foreground="White" FontWeight="SemiBold" FontSize="12"/>
-                                                </Border>
-                                            </StackPanel>
+                                            <ItemsControl Margin="0,4,0,0"
+                                                          ItemsSource="{Binding Badges}"
+                                                          Visibility="{Binding HasBadges, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Background="{Binding Background}"
+                                                                CornerRadius="4"
+                                                                Padding="6,2"
+                                                                Margin="0,0,6,0">
+                                                            <TextBlock Text="{Binding Label}"
+                                                                       Foreground="{Binding Foreground}"
+                                                                       FontWeight="SemiBold"
+                                                                       FontSize="12"/>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
                                             <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="{Binding CreatedAtDisplay}" Foreground="#a0a0a0"/>
                                                 <TextBlock Text="{Binding LastUpdatedDisplay}" Foreground="#a0a0a0" Margin="12,0,0,0"/>
@@ -111,7 +127,7 @@
                                         </Grid.ColumnDefinitions>
                                         <Button Width="72"
                                                 Height="72"
-                                                Command="{Binding DataContext.CheckLanguagesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                Command="{Binding DataContext.LoadBadgesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                                                 CommandParameter="{Binding}"
                                                 Style="{StaticResource TransparentButtonStyle}">
                                             <Border Background="#2d2d2d" CornerRadius="4">
@@ -119,19 +135,35 @@
                                             </Border>
                                         </Button>
                                         <StackPanel Grid.Column="2" VerticalAlignment="Center">
-                                            <Button Command="{Binding DataContext.CheckLanguagesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                            <Button Command="{Binding DataContext.LoadBadgesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                                                     CommandParameter="{Binding}"
                                                     Style="{StaticResource TransparentButtonStyle}"
                                                     HorizontalAlignment="Left">
                                                 <TextBlock Text="{Binding Name}" FontSize="16" FontWeight="Bold" Foreground="White"/>
                                             </Button>
                                             <TextBlock Text="{Binding DisplayAuthor}" Foreground="#d0d0d0"/>
-                                            <StackPanel Orientation="Horizontal" Margin="0,4,0,0"
-                                                        Visibility="{Binding HasLua, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                                <Border Background="#2962ff" CornerRadius="4" Padding="6,2">
-                                                    <TextBlock Text="Lua" Foreground="White" FontWeight="SemiBold" FontSize="12"/>
-                                                </Border>
-                                            </StackPanel>
+                                            <ItemsControl Margin="0,4,0,0"
+                                                          ItemsSource="{Binding Badges}"
+                                                          Visibility="{Binding HasBadges, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Background="{Binding Background}"
+                                                                CornerRadius="4"
+                                                                Padding="6,2"
+                                                                Margin="0,0,6,0">
+                                                            <TextBlock Text="{Binding Label}"
+                                                                       Foreground="{Binding Foreground}"
+                                                                       FontWeight="SemiBold"
+                                                                       FontSize="12"/>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
                                             <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="{Binding CreatedAtDisplay}" Foreground="#a0a0a0"/>
                                                 <TextBlock Text="{Binding LastUpdatedDisplay}" Foreground="#a0a0a0" Margin="12,0,0,0"/>
@@ -158,7 +190,7 @@
                                         </Grid.ColumnDefinitions>
                                         <Button Width="72"
                                                 Height="72"
-                                                Command="{Binding DataContext.CheckLanguagesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                Command="{Binding DataContext.LoadBadgesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                                                 CommandParameter="{Binding}"
                                                 Style="{StaticResource TransparentButtonStyle}">
                                             <Border Background="#2d2d2d" CornerRadius="4">
@@ -191,19 +223,35 @@
                                             </Border>
                                         </Button>
                                         <StackPanel Grid.Column="2" VerticalAlignment="Center">
-                                            <Button Command="{Binding DataContext.CheckLanguagesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                            <Button Command="{Binding DataContext.LoadBadgesCommand, RelativeSource={RelativeSource AncestorType=Window}}"
                                                     CommandParameter="{Binding}"
                                                     Style="{StaticResource TransparentButtonStyle}"
                                                     HorizontalAlignment="Left">
                                                 <TextBlock Text="{Binding Name}" FontSize="16" FontWeight="Bold" Foreground="White"/>
                                             </Button>
                                             <TextBlock Text="{Binding DisplayAuthor}" Foreground="#d0d0d0"/>
-                                            <StackPanel Orientation="Horizontal" Margin="0,4,0,0"
-                                                        Visibility="{Binding HasLua, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                                <Border Background="#2962ff" CornerRadius="4" Padding="6,2">
-                                                    <TextBlock Text="Lua" Foreground="White" FontWeight="SemiBold" FontSize="12"/>
-                                                </Border>
-                                            </StackPanel>
+                                            <ItemsControl Margin="0,4,0,0"
+                                                          ItemsSource="{Binding Badges}"
+                                                          Visibility="{Binding HasBadges, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Background="{Binding Background}"
+                                                                CornerRadius="4"
+                                                                Padding="6,2"
+                                                                Margin="0,0,6,0">
+                                                            <TextBlock Text="{Binding Label}"
+                                                                       Foreground="{Binding Foreground}"
+                                                                       FontWeight="SemiBold"
+                                                                       FontSize="12"/>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
                                             <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="{Binding CreatedAtDisplay}" Foreground="#a0a0a0"/>
                                                 <TextBlock Text="{Binding LastUpdatedDisplay}" Foreground="#a0a0a0" Margin="12,0,0,0"/>

--- a/OpenKh.Tools.ModBrowser/Models/ModBadge.cs
+++ b/OpenKh.Tools.ModBrowser/Models/ModBadge.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace OpenKh.Tools.ModBrowser.Models;
+
+public class ModBadge : IEquatable<ModBadge>
+{
+    public ModBadge(string label, string background, string foreground)
+    {
+        Label = label ?? throw new ArgumentNullException(nameof(label));
+        Background = background ?? throw new ArgumentNullException(nameof(background));
+        Foreground = foreground ?? throw new ArgumentNullException(nameof(foreground));
+    }
+
+    public string Label { get; }
+
+    public string Background { get; }
+
+    public string Foreground { get; }
+
+    public bool Equals(ModBadge? other) =>
+        other != null && string.Equals(Label, other.Label, StringComparison.OrdinalIgnoreCase);
+
+    public override bool Equals(object? obj) => obj is ModBadge badge && Equals(badge);
+
+    public override int GetHashCode() =>
+        StringComparer.OrdinalIgnoreCase.GetHashCode(Label);
+
+    public static ModBadge CreateLua() => new("Lua", "#2962ff", "White");
+
+    public static ModBadge CreatePc() => new("PC", "#40C4FF", "Black");
+
+    public static ModBadge CreateHd() => new("HD", "#E53935", "White");
+
+    public static ModBadge CreatePs2() => new("PS2", "#B0BEC5", "Black");
+
+    public static ModBadge CreateHeavy() => new("Heavy", "#FB8C00", "Black");
+}

--- a/OpenKh.Tools.ModBrowser/Models/ModEntry.cs
+++ b/OpenKh.Tools.ModBrowser/Models/ModEntry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 
@@ -20,7 +21,7 @@ public class ModEntry : INotifyPropertyChanged
         DateTime? lastPush,
         string? iconUrl,
         ModCategory category,
-        bool hasLua)
+        string? modYmlUrl)
     {
         Repo = repo;
         Author = author;
@@ -28,7 +29,7 @@ public class ModEntry : INotifyPropertyChanged
         LastPush = lastPush;
         IconUrl = string.IsNullOrWhiteSpace(iconUrl) ? null : iconUrl;
         Category = category;
-        _hasLua = hasLua;
+        ModYmlUrl = string.IsNullOrWhiteSpace(modYmlUrl) ? null : modYmlUrl;
     }
 
     public string Repo { get; }
@@ -47,37 +48,42 @@ public class ModEntry : INotifyPropertyChanged
 
     public ModCategory Category { get; }
 
-    private bool _hasLua;
+    public string? ModYmlUrl { get; }
 
-    public bool HasLua
+    private IReadOnlyList<ModBadge> _badges = Array.Empty<ModBadge>();
+
+    public IReadOnlyList<ModBadge> Badges
     {
-        get => _hasLua;
+        get => _badges;
         private set
         {
-            if (_hasLua == value)
+            if (ReferenceEquals(_badges, value))
             {
                 return;
             }
 
-            _hasLua = value;
-            OnPropertyChanged(nameof(HasLua));
+            _badges = value;
+            OnPropertyChanged(nameof(Badges));
+            OnPropertyChanged(nameof(HasBadges));
         }
     }
 
-    private bool _isCheckingLanguages;
+    public bool HasBadges => Badges.Count > 0;
 
-    public bool IsCheckingLanguages
+    private bool _isLoadingBadges;
+
+    public bool IsLoadingBadges
     {
-        get => _isCheckingLanguages;
+        get => _isLoadingBadges;
         private set
         {
-            if (_isCheckingLanguages == value)
+            if (_isLoadingBadges == value)
             {
                 return;
             }
 
-            _isCheckingLanguages = value;
-            OnPropertyChanged(nameof(IsCheckingLanguages));
+            _isLoadingBadges = value;
+            OnPropertyChanged(nameof(IsLoadingBadges));
         }
     }
 
@@ -93,9 +99,9 @@ public class ModEntry : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
-    public void UpdateLuaUsage(bool hasLua) => HasLua = hasLua;
+    public void UpdateBadges(IReadOnlyList<ModBadge>? badges) => Badges = badges ?? Array.Empty<ModBadge>();
 
-    public void SetCheckingLanguages(bool isChecking) => IsCheckingLanguages = isChecking;
+    public void SetLoadingBadges(bool isLoading) => IsLoadingBadges = isLoading;
 
     private void OnPropertyChanged(string propertyName) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj
+++ b/OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenKh.Tools.Common.Wpf\OpenKh.Tools.Common.Wpf.csproj" />
+    <PackageReference Include="YamlDotNet" Version="15.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- introduce a reusable ModBadge model and expose badge collections on ModEntry
- analyze the GitHub repository tree and mod.yml contents to derive Lua/PC/HD/PS2/Heavy badges
- update the Mod Browser UI to display multiple badges and fetch mod.yml via YamlDotNet

## Testing
- `dotnet build OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de284bc434832985b2e7ccec301acf