### PR TITLE
Add context menu to open mods in browser

### DIFF
--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -1,4 +1,5 @@
 <Window x:Class="OpenKh.Tools.ModBrowser.MainWindow"
+        x:Name="MainWindowRoot"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="KH Mod Browser" Height="600" Width="900" MinWidth="640" MinHeight="480"
@@ -56,6 +57,13 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border BorderThickness="0,0,0,1" BorderBrush="#2d2d2d" Padding="8">
+                                    <Border.ContextMenu>
+                                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                            <MenuItem Header="Open in Browser"
+                                                      Command="{Binding DataContext.OpenInBrowserCommand, Source={x:Reference MainWindowRoot}}"
+                                                      CommandParameter="{Binding}" />
+                                        </ContextMenu>
+                                    </Border.ContextMenu>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>
@@ -119,6 +127,13 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border BorderThickness="0,0,0,1" BorderBrush="#2d2d2d" Padding="8">
+                                    <Border.ContextMenu>
+                                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                            <MenuItem Header="Open in Browser"
+                                                      Command="{Binding DataContext.OpenInBrowserCommand, Source={x:Reference MainWindowRoot}}"
+                                                      CommandParameter="{Binding}" />
+                                        </ContextMenu>
+                                    </Border.ContextMenu>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>
@@ -182,6 +197,13 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border BorderThickness="0,0,0,1" BorderBrush="#2d2d2d" Padding="8">
+                                    <Border.ContextMenu>
+                                        <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                            <MenuItem Header="Open in Browser"
+                                                      Command="{Binding DataContext.OpenInBrowserCommand, Source={x:Reference MainWindowRoot}}"
+                                                      CommandParameter="{Binding}" />
+                                        </ContextMenu>
+                                    </Border.ContextMenu>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
## Summary
- add a context menu to each mod entry so a right click exposes an Open in Browser action
- route the menu item to a view-model command that opens the associated GitHub repository in the default browser

## Testing
- dotnet build OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dea4725e348329a94ba03d9afd72a8