### PR TITLE
Add toolbar option to import mods from GitHub

### DIFF
--- a/OpenKh.Tools.ModBrowser/AddModWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/AddModWindow.xaml
@@ -1,0 +1,39 @@
+<Window x:Class="OpenKh.Tools.ModBrowser.AddModWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Add Mod"
+        Height="180"
+        Width="420"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Background="#1f1f1f"
+        Foreground="White">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock Text="Enter a GitHub repository (author/repo or URL):"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,8"/>
+        <TextBox x:Name="RepositoryTextBox"
+                 Grid.Row="1"
+                 Background="#2d2d2d"
+                 Foreground="White"
+                 BorderBrush="#3f3f3f"
+                 Margin="0,0,0,12"/>
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+            <Button Content="Cancel"
+                    Width="80"
+                    Margin="0,0,8,0"
+                    IsCancel="True"/>
+            <Button Content="Add"
+                    Width="80"
+                    IsDefault="True"
+                    Click="OnAddClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/OpenKh.Tools.ModBrowser/AddModWindow.xaml.cs
+++ b/OpenKh.Tools.ModBrowser/AddModWindow.xaml.cs
@@ -1,0 +1,25 @@
+using System.Windows;
+
+namespace OpenKh.Tools.ModBrowser;
+
+public partial class AddModWindow : Window
+{
+    public AddModWindow()
+    {
+        InitializeComponent();
+        Loaded += (_, _) => RepositoryTextBox.Focus();
+    }
+
+    public string RepositoryInput => RepositoryTextBox.Text.Trim();
+
+    private void OnAddClicked(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(RepositoryTextBox.Text))
+        {
+            MessageBox.Show(this, "Please enter a repository before continuing.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        DialogResult = true;
+    }
+}

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -62,10 +62,15 @@
             <StackPanel>
                 <ToolBarTray Background="Transparent" IsLocked="True">
                     <ToolBar Background="Transparent" BorderBrush="#3f3f3f" Foreground="White">
-                        <Button Content="Add Mod"
-                                Padding="12,4"
-                                Margin="0,0,8,0"
-                                Click="AddModButton_Click"/>
+                        <Menu Background="Transparent"
+                              Foreground="White"
+                              BorderBrush="{x:Null}"
+                              Margin="0,0,8,0">
+                            <MenuItem Header="Mods">
+                                <MenuItem Header="Add Mod..."
+                                          Click="AddModMenuItem_Click"/>
+                            </MenuItem>
+                        </Menu>
                     </ToolBar>
                 </ToolBarTray>
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -59,7 +59,16 @@
     </Window.Resources>
     <DockPanel>
         <Border DockPanel.Dock="Top" Background="#1f1f1f" Padding="12">
-            <StackPanel Orientation="Horizontal">
+            <StackPanel>
+                <ToolBarTray Background="Transparent" IsLocked="True">
+                    <ToolBar Background="Transparent" BorderBrush="#3f3f3f" Foreground="White">
+                        <Button Content="Add Mod"
+                                Padding="12,4"
+                                Margin="0,0,8,0"
+                                Click="AddModButton_Click"/>
+                    </ToolBar>
+                </ToolBarTray>
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                 <TextBox Width="400"
                          Background="#2d2d2d"
                          Foreground="White"
@@ -83,6 +92,7 @@
                         </Style>
                     </ComboBox.ItemContainerStyle>
                 </ComboBox>
+                </StackPanel>
             </StackPanel>
         </Border>
         <TabControl Background="Transparent" Foreground="White">

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using OpenKh.Tools.ModBrowser.ViewModels;
 
@@ -9,5 +11,61 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         DataContext = new MainViewModel();
+    }
+
+    private async void AddModButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainViewModel viewModel)
+        {
+            return;
+        }
+
+        var dialog = new AddModWindow
+        {
+            Owner = this
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        var repositoryInput = dialog.RepositoryInput;
+        if (string.IsNullOrWhiteSpace(repositoryInput))
+        {
+            return;
+        }
+
+        AddModStatus status;
+        try
+        {
+            status = await viewModel.AddModAsync(repositoryInput, CancellationToken.None);
+        }
+        catch (TaskCanceledException)
+        {
+            return;
+        }
+
+        switch (status)
+        {
+            case AddModStatus.Success:
+                MessageBox.Show(this, "The mod was added successfully.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Information);
+                break;
+            case AddModStatus.AlreadyExists:
+                MessageBox.Show(this, "That repository already exists in mods.json.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Information);
+                break;
+            case AddModStatus.InvalidRepository:
+                MessageBox.Show(this, "Enter a repository in the form \"author/repo\" or a GitHub URL.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Warning);
+                break;
+            case AddModStatus.RepositoryNotFound:
+                MessageBox.Show(this, "The repository could not be found on GitHub.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Error);
+                break;
+            case AddModStatus.ModsFileUnavailable:
+                MessageBox.Show(this, "A mods.json file could not be located. Ensure it exists alongside the application.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Error);
+                break;
+            default:
+                MessageBox.Show(this, "An unexpected error occurred while adding the mod.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Error);
+                break;
+        }
     }
 }

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
@@ -13,7 +13,7 @@ public partial class MainWindow : Window
         DataContext = new MainViewModel();
     }
 
-    private async void AddModButton_Click(object sender, RoutedEventArgs e)
+    private async void AddModMenuItem_Click(object sender, RoutedEventArgs e)
     {
         if (DataContext is not MainViewModel viewModel)
         {

--- a/OpenKh.Tools.ModBrowser/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModBrowser/ViewModels/MainViewModel.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -18,6 +19,16 @@ using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
 
 namespace OpenKh.Tools.ModBrowser.ViewModels;
+
+public enum AddModStatus
+{
+    Success,
+    ModsFileUnavailable,
+    InvalidRepository,
+    AlreadyExists,
+    RepositoryNotFound,
+    Failed
+}
 
 public class MainViewModel : INotifyPropertyChanged
 {
@@ -97,6 +108,75 @@ public class MainViewModel : INotifyPropertyChanged
             _activeFilters = SearchFilters.Parse(value);
             OnPropertyChanged(nameof(SearchQuery));
             RefreshViews();
+        }
+    }
+
+    public async Task<AddModStatus> AddModAsync(string repositoryInput, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(repositoryInput))
+        {
+            return AddModStatus.InvalidRepository;
+        }
+
+        if (_modsFilePath == null)
+        {
+            _modsFilePath = ResolveModsFilePath();
+            if (_modsFilePath == null)
+            {
+                return AddModStatus.ModsFileUnavailable;
+            }
+        }
+
+        var normalizedRepo = NormalizeRepositoryInput(repositoryInput);
+        if (normalizedRepo == null)
+        {
+            return AddModStatus.InvalidRepository;
+        }
+
+        if (_modJsonEntryMap.ContainsKey(normalizedRepo))
+        {
+            return AddModStatus.AlreadyExists;
+        }
+
+        try
+        {
+            var entry = await BuildEntryForRepositoryAsync(normalizedRepo, cancellationToken);
+            if (entry == null)
+            {
+                return AddModStatus.RepositoryNotFound;
+            }
+
+            _modJsonEntries.Add(entry);
+            if (!string.IsNullOrWhiteSpace(entry.Repo))
+            {
+                _modJsonEntryMap[entry.Repo] = entry;
+            }
+
+            var category = DetermineCategory(entry);
+            var iconUrl = ExtractIconUrl(entry);
+            var modYmlUrl = ExtractModYmlUrl(entry);
+            var modEntry = new ModEntry(
+                entry.Repo,
+                entry.Author,
+                entry.CreatedAt,
+                entry.LastPush,
+                iconUrl,
+                category,
+                modYmlUrl);
+
+            _mods.Add(modEntry);
+            RefreshViews();
+
+            await PersistModsJsonAsync(cancellationToken);
+            return AddModStatus.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return AddModStatus.Failed;
         }
     }
 
@@ -374,6 +454,134 @@ public class MainViewModel : INotifyPropertyChanged
 
         var badgeArray = badges.Count > 0 ? badges.ToArray() : Array.Empty<ModBadge>();
         return new BadgeQueryResult(badgeArray, createdAt, lastPush);
+    }
+
+    private async Task<ModJsonEntry?> BuildEntryForRepositoryAsync(string repository, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(repository))
+        {
+            return null;
+        }
+
+        using var response = await _httpClient
+            .GetAsync($"https://api.github.com/repos/{repository}", cancellationToken)
+            .ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var root = document.RootElement;
+
+        var repoFullName = repository;
+        if (root.TryGetProperty("full_name", out var fullNameElement) && fullNameElement.ValueKind == JsonValueKind.String)
+        {
+            var fullName = fullNameElement.GetString();
+            if (!string.IsNullOrWhiteSpace(fullName))
+            {
+                repoFullName = fullName!;
+            }
+        }
+
+        string? author = null;
+        if (root.TryGetProperty("owner", out var ownerElement) && ownerElement.ValueKind == JsonValueKind.Object)
+        {
+            if (ownerElement.TryGetProperty("login", out var loginElement) && loginElement.ValueKind == JsonValueKind.String)
+            {
+                author = loginElement.GetString();
+            }
+        }
+
+        DateTime? createdAt = null;
+        if (root.TryGetProperty("created_at", out var createdAtElement) && createdAtElement.ValueKind == JsonValueKind.String)
+        {
+            createdAt = ParseGitHubDate(createdAtElement.GetString());
+        }
+
+        DateTime? lastPush = null;
+        if (root.TryGetProperty("pushed_at", out var pushedAtElement) && pushedAtElement.ValueKind == JsonValueKind.String)
+        {
+            lastPush = ParseGitHubDate(pushedAtElement.GetString());
+        }
+
+        var languages = await FetchRepositoryLanguagesAsync(repoFullName, cancellationToken).ConfigureAwait(false);
+        var paths = await FetchRepositoryTreeAsync(repoFullName, cancellationToken).ConfigureAwait(false);
+
+        var matchesDictionary = new Dictionary<string, ModJsonMatch>(StringComparer.OrdinalIgnoreCase);
+        string? modYmlUrl = null;
+        string? iconUrl = null;
+
+        var modYmlPath = FindRepositoryPath(paths, "mod.yml");
+        if (modYmlPath != null)
+        {
+            modYmlUrl = BuildRawGitHubUrl(repoFullName, modYmlPath);
+            matchesDictionary["mod.yml"] = new ModJsonMatch
+            {
+                Exists = true,
+                Url = modYmlUrl
+            };
+        }
+
+        var iconPath = FindRepositoryPath(paths, "icon.png");
+        if (iconPath != null)
+        {
+            iconUrl = BuildRawGitHubUrl(repoFullName, iconPath);
+            matchesDictionary["icon.png"] = new ModJsonMatch
+            {
+                Exists = true,
+                Url = iconUrl
+            };
+        }
+
+        Dictionary<string, ModJsonMatch>? matches = matchesDictionary.Count > 0 ? matchesDictionary : null;
+
+        return new ModJsonEntry
+        {
+            Repo = repoFullName,
+            Author = string.IsNullOrWhiteSpace(author) ? null : author,
+            CreatedAt = createdAt,
+            LastPush = lastPush,
+            Matches = matches,
+            ModYmlUrl = modYmlUrl,
+            HasIcon = iconPath != null && string.Equals(iconPath, "icon.png", StringComparison.OrdinalIgnoreCase) ? true : null,
+            Languages = languages
+        };
+    }
+
+    private async Task<Dictionary<string, long>?> FetchRepositoryLanguagesAsync(string repo, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            return null;
+        }
+
+        using var response = await _httpClient
+            .GetAsync($"https://api.github.com/repos/{repo}/languages", cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var languages = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in document.RootElement.EnumerateObject())
+        {
+            if (property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetInt64(out var bytes))
+            {
+                languages[property.Name] = bytes;
+            }
+        }
+
+        return languages.Count > 0 ? languages : null;
     }
 
     private async Task<RepositoryLanguageMetadata?> FetchRepositoryLanguageMetadataAsync(string repo, CancellationToken cancellationToken)
@@ -1041,6 +1249,61 @@ public class MainViewModel : INotifyPropertyChanged
         }
 
         return $"https://raw.githubusercontent.com/{repo}/HEAD/{relativePath}";
+    }
+
+    private static string? FindRepositoryPath(IEnumerable<string> paths, string fileName)
+    {
+        if (paths == null)
+        {
+            return null;
+        }
+
+        return paths
+            .Where(path => path.EndsWith(fileName, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(path => path.Count(ch => ch == '/' || ch == '\\'))
+            .ThenBy(path => path.Length)
+            .FirstOrDefault();
+    }
+
+    private static string? NormalizeRepositoryInput(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var candidate = value.Trim();
+
+        if (Uri.TryCreate(candidate, UriKind.Absolute, out var uri))
+        {
+            if (!string.Equals(uri.Host, "github.com", StringComparison.OrdinalIgnoreCase) &&
+                !uri.Host.EndsWith(".github.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length < 2)
+            {
+                return null;
+            }
+
+            candidate = $"{segments[0]}/{segments[1]}";
+        }
+
+        candidate = candidate.Trim('/');
+
+        if (candidate.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            candidate = candidate[..^4];
+        }
+
+        if (candidate.Count(ch => ch == '/') != 1)
+        {
+            return null;
+        }
+
+        return candidate;
     }
 
     private bool MatchesSearch(ModEntry mod)


### PR DESCRIPTION
## Summary
- add a toolbar button that opens an Add Mod dialog in the Mod Browser
- implement dialog and view-model logic to fetch GitHub metadata and append new entries to mods.json
- update the UI workflow to refresh the list and report status after adding a repository

## Testing
- dotnet build OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e03c6ab7f883299565e5780a7f255b