### PR TITLE
Add menu-driven mod addition workflow to KH Mod Browser

### DIFF
--- a/OpenKh.Tools.ModBrowser/AddModWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/AddModWindow.xaml
@@ -1,0 +1,38 @@
+<Window x:Class="OpenKh.Tools.ModBrowser.AddModWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Add Mod" Height="160" Width="400"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Background="#1f1f1f" Foreground="White">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock Text="Enter a GitHub repository (author/repo or URL):"
+                   Margin="0,0,0,8" />
+        <TextBox x:Name="RepoTextBox"
+                 Grid.Row="1"
+                 Background="#2d2d2d"
+                 Foreground="White"
+                 BorderBrush="#3f3f3f"
+                 Padding="4"
+                 MinWidth="240" />
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,12,0,0">
+            <Button Content="Cancel"
+                    Width="80"
+                    Margin="0,0,8,0"
+                    IsCancel="True"
+                    Click="OnCancelClick" />
+            <Button Content="Add"
+                    Width="80"
+                    IsDefault="True"
+                    Click="OnAddClick" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/OpenKh.Tools.ModBrowser/AddModWindow.xaml.cs
+++ b/OpenKh.Tools.ModBrowser/AddModWindow.xaml.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+
+namespace OpenKh.Tools.ModBrowser;
+
+public partial class AddModWindow : Window
+{
+    public AddModWindow()
+    {
+        InitializeComponent();
+        Loaded += (_, _) => RepoTextBox.Focus();
+    }
+
+    public string? RepositoryInput { get; private set; }
+
+    private void OnAddClick(object sender, RoutedEventArgs e)
+    {
+        var input = RepoTextBox.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            MessageBox.Show(this, "Please enter a repository before continuing.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Warning);
+            RepoTextBox.Focus();
+            return;
+        }
+
+        RepositoryInput = input;
+        DialogResult = true;
+    }
+
+    private void OnCancelClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -58,6 +58,14 @@
         </Style>
     </Window.Resources>
     <DockPanel>
+        <Menu DockPanel.Dock="Top"
+              Background="#1f1f1f"
+              Foreground="White">
+            <MenuItem Header="_Options">
+                <MenuItem Header="_Add mod"
+                          Click="OnAddModClick" />
+            </MenuItem>
+        </Menu>
         <Border DockPanel.Dock="Top" Background="#1f1f1f" Padding="12">
             <StackPanel Orientation="Horizontal">
                 <TextBox Width="400"

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -58,14 +58,26 @@
         </Style>
     </Window.Resources>
     <DockPanel>
-        <Menu DockPanel.Dock="Top"
-              Background="#1f1f1f"
-              Foreground="White">
-            <MenuItem Header="_Options">
-                <MenuItem Header="_Add mod"
-                          Click="OnAddModClick" />
-            </MenuItem>
-        </Menu>
+        <ToolBarTray DockPanel.Dock="Top"
+                     Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
+            <ToolBar Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+                     Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                     BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                     BorderThickness="0,0,0,1"
+                     Padding="2"
+                     Margin="0">
+                <Menu Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+                      Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                      BorderThickness="0"
+                      Margin="0"
+                      Padding="0">
+                    <MenuItem Header="_Options">
+                        <MenuItem Header="_Add mod"
+                                  Click="OnAddModClick" />
+                    </MenuItem>
+                </Menu>
+            </ToolBar>
+        </ToolBarTray>
         <Border DockPanel.Dock="Top" Background="#1f1f1f" Padding="12">
             <StackPanel Orientation="Horizontal">
                 <TextBox Width="400"

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -56,21 +56,36 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+        <Style x:Key="FlatToolBarStyle" TargetType="ToolBar">
+            <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" />
+            <Setter Property="BorderThickness" Value="0,0,0,1" />
+            <Setter Property="Padding" Value="2" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToolBar">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}">
+                            <ToolBarPanel Margin="0" IsItemsHost="True" />
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Window.Resources>
     <DockPanel>
         <ToolBarTray DockPanel.Dock="Top"
+                     IsLocked="True"
                      Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
-            <ToolBar Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
-                     Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-                     BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
-                     BorderThickness="0,0,0,1"
-                     Padding="2"
-                     Margin="0">
+            <ToolBar Style="{StaticResource FlatToolBarStyle}">
                 <Menu Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
                       Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                       BorderThickness="0"
                       Margin="0"
-                      Padding="0">
+                      Padding="0"
+                      ToolBar.OverflowMode="Never">
                     <MenuItem Header="_Options">
                         <MenuItem Header="_Add mod"
                                   Click="OnAddModClick" />

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
@@ -10,4 +10,43 @@ public partial class MainWindow : Window
         InitializeComponent();
         DataContext = new MainViewModel();
     }
+
+    private async void OnAddModClick(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainViewModel viewModel)
+        {
+            return;
+        }
+
+        var dialog = new AddModWindow
+        {
+            Owner = this
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        var result = await viewModel.AddModAsync(dialog.RepositoryInput);
+
+        switch (result)
+        {
+            case MainViewModel.AddModResult.Added:
+                MessageBox.Show(this, "The mod was added successfully.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Information);
+                break;
+            case MainViewModel.AddModResult.AlreadyExists:
+                MessageBox.Show(this, "This mod is already listed.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Information);
+                break;
+            case MainViewModel.AddModResult.InvalidInput:
+                MessageBox.Show(this, "Enter a valid GitHub repository in the form author/repo or a GitHub URL.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Warning);
+                break;
+            case MainViewModel.AddModResult.NotFound:
+                MessageBox.Show(this, "The specified repository could not be found on GitHub.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Warning);
+                break;
+            case MainViewModel.AddModResult.Failed:
+                MessageBox.Show(this, "An error occurred while adding the mod. Please try again later.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Error);
+                break;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add an Options > Add mod menu that opens a dialog for pasting a GitHub repository
- implement view-model logic to normalize repository input, fetch metadata, and update mods.json and the in-memory list
- extend GitHub metadata fetching to capture owner and language information for new entries

## Testing
- dotnet build OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e045a0032c83299a4117439b7ffa96