### PR TITLE
Add GitHub follow support to Mod Browser

### DIFF
--- a/OpenKh.Tools.ModBrowser/FollowUserWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/FollowUserWindow.xaml
@@ -1,0 +1,37 @@
+<Window x:Class="OpenKh.Tools.ModBrowser.FollowUserWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Follow User" Height="140" Width="360"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Background="#1f1f1f" Foreground="White">
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock Text="Enter a GitHub username:" Margin="0,0,0,8" />
+        <TextBox x:Name="UsernameTextBox"
+                 Grid.Row="1"
+                 Background="#2d2d2d"
+                 Foreground="White"
+                 BorderBrush="#3f3f3f"
+                 Padding="4"
+                 MinWidth="240" />
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,12,0,0">
+            <Button Content="Cancel"
+                    Width="80"
+                    Margin="0,0,8,0"
+                    IsCancel="True"
+                    Click="OnCancelClick" />
+            <Button Content="Follow"
+                    Width="80"
+                    IsDefault="True"
+                    Click="OnFollowClick" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/OpenKh.Tools.ModBrowser/FollowUserWindow.xaml.cs
+++ b/OpenKh.Tools.ModBrowser/FollowUserWindow.xaml.cs
@@ -1,0 +1,33 @@
+using System.Windows;
+
+namespace OpenKh.Tools.ModBrowser;
+
+public partial class FollowUserWindow : Window
+{
+    public FollowUserWindow()
+    {
+        InitializeComponent();
+        Loaded += (_, _) => UsernameTextBox.Focus();
+    }
+
+    public string? UsernameInput { get; private set; }
+
+    private void OnFollowClick(object sender, RoutedEventArgs e)
+    {
+        var input = UsernameTextBox.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            MessageBox.Show(this, "Please enter a username before continuing.", "Follow User", MessageBoxButton.OK, MessageBoxImage.Warning);
+            UsernameTextBox.Focus();
+            return;
+        }
+
+        UsernameInput = input;
+        DialogResult = true;
+    }
+
+    private void OnCancelClick(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -90,6 +90,10 @@
                         <MenuItem Header="_Add mod"
                                   Click="OnAddModClick" />
                     </MenuItem>
+                    <MenuItem Header="_Tools">
+                        <MenuItem Header="_Follow"
+                                  Click="OnFollowClick" />
+                    </MenuItem>
                 </Menu>
             </ToolBar>
         </ToolBarTray>

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Windows;
 using OpenKh.Tools.ModBrowser.ViewModels;
 
@@ -46,6 +47,55 @@ public partial class MainWindow : Window
                 break;
             case MainViewModel.AddModResult.Failed:
                 MessageBox.Show(this, "An error occurred while adding the mod. Please try again later.", "Add Mod", MessageBoxButton.OK, MessageBoxImage.Error);
+                break;
+        }
+    }
+
+    private async void OnFollowClick(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainViewModel viewModel)
+        {
+            return;
+        }
+
+        var dialog = new FollowUserWindow
+        {
+            Owner = this
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        var result = await viewModel.FollowUserAsync(dialog.UsernameInput);
+
+        switch (result.Status)
+        {
+            case MainViewModel.FollowUserStatus.InvalidInput:
+                MessageBox.Show(this, "Enter a valid GitHub username.", "Follow User", MessageBoxButton.OK, MessageBoxImage.Warning);
+                break;
+            case MainViewModel.FollowUserStatus.NotFound:
+                MessageBox.Show(this, $"The GitHub user \"{result.Username}\" could not be found.", "Follow User", MessageBoxButton.OK, MessageBoxImage.Warning);
+                break;
+            case MainViewModel.FollowUserStatus.Failed:
+                MessageBox.Show(this, "An error occurred while fetching repositories. Please try again later.", "Follow User", MessageBoxButton.OK, MessageBoxImage.Error);
+                break;
+            case MainViewModel.FollowUserStatus.Success:
+                var builder = new StringBuilder();
+                builder.AppendLine($"Fetched {result.TotalRepositories} repositories for {result.Username}.");
+                builder.AppendLine($"{result.AddedCount} new mods were added to the list.");
+                if (result.AlreadyTrackedCount > 0)
+                {
+                    builder.AppendLine($"{result.AlreadyTrackedCount} repositories were already present.");
+                }
+
+                if (result.FailedCount > 0)
+                {
+                    builder.AppendLine($"{result.FailedCount} repositories could not be added.");
+                }
+
+                MessageBox.Show(this, builder.ToString(), "Follow User", MessageBoxButton.OK, MessageBoxImage.Information);
                 break;
         }
     }


### PR DESCRIPTION
## Summary
- add a Tools > Follow menu entry and dialog to prompt for a GitHub username
- fetch all repositories for followed users, append missing mods, and persist the followed list with de-duplication

## Testing
- dotnet build OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e05322a92883298a04bad8bf946ce7