### PR TITLE
Persist mod badge cache between sessions

### DIFF
--- a/OpenKh.Tools.ModBrowser/Models/ModJsonModel.cs
+++ b/OpenKh.Tools.ModBrowser/Models/ModJsonModel.cs
@@ -38,4 +38,19 @@ public class ModJsonEntry
 
     [JsonPropertyName("languages")]
     public Dictionary<string, long>? Languages { get; set; }
+
+    [JsonPropertyName("badges")]
+    public List<ModJsonBadge>? Badges { get; set; }
+}
+
+public class ModJsonBadge
+{
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+
+    [JsonPropertyName("background")]
+    public string? Background { get; set; }
+
+    [JsonPropertyName("foreground")]
+    public string? Foreground { get; set; }
 }


### PR DESCRIPTION
## Summary
- store badge metadata in mods.json so cached badges survive restarts
- hydrate mod entries from cached badges while still triggering live refreshes on click
- persist refreshed badge information back to disk alongside other repository metadata

## Testing
- `dotnet build OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj` *(fails: dotnet CLI is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e05d350e7c8329bf3ffc26f2150b51