### PR TITLE
Handle non-404 GitHub repo responses

### DIFF
--- a/OpenKh.Tools.ModBrowser/ViewModels/MainViewModel.cs
+++ b/OpenKh.Tools.ModBrowser/ViewModels/MainViewModel.cs
@@ -786,10 +786,12 @@ public class MainViewModel : INotifyPropertyChanged
             .GetAsync($"https://api.github.com/repos/{repo}", cancellationToken)
             .ConfigureAwait(false))
         {
-            if (!response.IsSuccessStatusCode)
+            if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 return null;
             }
+
+            response.EnsureSuccessStatusCode();
 
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- ensure the repository metadata fetch distinguishes 404s from other HTTP failures
- surface unexpected HTTP failures so add/follow operations report a failed status

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07310ec588329b1b9a81ca7e9d3e2