### PR TITLE
Improve manual mod updates and icon caching

### DIFF
--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -153,7 +153,35 @@
                                                 CommandParameter="{Binding}"
                                                 Style="{StaticResource TransparentButtonStyle}">
                                             <Border Background="#2d2d2d" CornerRadius="4">
-                                                <Image Source="{Binding IconUrl}" Stretch="UniformToFill"/>
+                                                <Grid>
+                                                    <Image Source="{Binding IconUrl}" Stretch="UniformToFill">
+                                                        <Image.Style>
+                                                            <Style TargetType="Image">
+                                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding HasIcon}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Visible" />
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </Image.Style>
+                                                    </Image>
+                                                    <TextBlock Text="Unknown"
+                                                               VerticalAlignment="Center"
+                                                               HorizontalAlignment="Center"
+                                                               Foreground="#a0a0a0">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Setter Property="Visibility" Value="Visible" />
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding HasIcon}" Value="True">
+                                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </Grid>
                                             </Border>
                                         </Button>
                                         <StackPanel Grid.Column="2" VerticalAlignment="Center">

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml
@@ -134,6 +134,8 @@
                             <Border BorderThickness="0,0,0,1" BorderBrush="#2d2d2d" Padding="8">
                                     <Border.ContextMenu>
                                         <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                            <MenuItem Header="Update Metadata"
+                                                      Click="OnUpdateModClick" />
                                             <MenuItem Header="Open in Browser"
                                                       Command="{Binding DataContext.OpenInBrowserCommand, Source={x:Reference MainWindowRoot}}"
                                                       CommandParameter="{Binding}" />
@@ -204,6 +206,8 @@
                             <Border BorderThickness="0,0,0,1" BorderBrush="#2d2d2d" Padding="8">
                                     <Border.ContextMenu>
                                         <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                            <MenuItem Header="Update Metadata"
+                                                      Click="OnUpdateModClick" />
                                             <MenuItem Header="Open in Browser"
                                                       Command="{Binding DataContext.OpenInBrowserCommand, Source={x:Reference MainWindowRoot}}"
                                                       CommandParameter="{Binding}" />
@@ -274,6 +278,8 @@
                             <Border BorderThickness="0,0,0,1" BorderBrush="#2d2d2d" Padding="8">
                                     <Border.ContextMenu>
                                         <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                            <MenuItem Header="Update Metadata"
+                                                      Click="OnUpdateModClick" />
                                             <MenuItem Header="Open in Browser"
                                                       Command="{Binding DataContext.OpenInBrowserCommand, Source={x:Reference MainWindowRoot}}"
                                                       CommandParameter="{Binding}" />

--- a/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
+++ b/OpenKh.Tools.ModBrowser/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Windows;
+using OpenKh.Tools.ModBrowser.Models;
 using OpenKh.Tools.ModBrowser.ViewModels;
 
 namespace OpenKh.Tools.ModBrowser;
@@ -96,6 +97,39 @@ public partial class MainWindow : Window
                 }
 
                 MessageBox.Show(this, builder.ToString(), "Follow User", MessageBoxButton.OK, MessageBoxImage.Information);
+                break;
+        }
+    }
+
+    private async void OnUpdateModClick(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainViewModel viewModel)
+        {
+            return;
+        }
+
+        if (sender is not FrameworkElement element || element.DataContext is not ModEntry entry)
+        {
+            return;
+        }
+
+        var result = await viewModel.UpdateModAsync(entry);
+        switch (result)
+        {
+            case MainViewModel.UpdateModResult.Success:
+                MessageBox.Show(this, "The mod entry was updated successfully.", "Update Metadata", MessageBoxButton.OK, MessageBoxImage.Information);
+                break;
+            case MainViewModel.UpdateModResult.NotTracked:
+                MessageBox.Show(this, "The selected mod could not be found in the local list.", "Update Metadata", MessageBoxButton.OK, MessageBoxImage.Warning);
+                break;
+            case MainViewModel.UpdateModResult.NotFound:
+                MessageBox.Show(this, "The repository could not be found on GitHub.", "Update Metadata", MessageBoxButton.OK, MessageBoxImage.Warning);
+                break;
+            case MainViewModel.UpdateModResult.Offline:
+                MessageBox.Show(this, "Unable to reach GitHub. Please check your connection and try again.", "Update Metadata", MessageBoxButton.OK, MessageBoxImage.Warning);
+                break;
+            case MainViewModel.UpdateModResult.Failed:
+                MessageBox.Show(this, "An error occurred while updating the mod entry. Please try again later.", "Update Metadata", MessageBoxButton.OK, MessageBoxImage.Error);
                 break;
         }
     }

--- a/OpenKh.Tools.ModBrowser/Models/ModEntry.cs
+++ b/OpenKh.Tools.ModBrowser/Models/ModEntry.cs
@@ -17,6 +17,9 @@ public class ModEntry : INotifyPropertyChanged
     private DateTime? _createdAt;
     private DateTime? _lastPush;
     private string? _iconPath;
+    private string? _remoteIconUrl;
+    private ModCategory _category;
+    private string? _modYmlUrl;
 
     public ModEntry(
         string repo,
@@ -31,10 +34,10 @@ public class ModEntry : INotifyPropertyChanged
         Author = author;
         _createdAt = createdAt;
         _lastPush = lastPush;
-        RemoteIconUrl = string.IsNullOrWhiteSpace(iconUrl) ? null : iconUrl;
-        IconUrl = RemoteIconUrl;
-        Category = category;
-        ModYmlUrl = string.IsNullOrWhiteSpace(modYmlUrl) ? null : modYmlUrl;
+        _remoteIconUrl = string.IsNullOrWhiteSpace(iconUrl) ? null : iconUrl;
+        IconUrl = _remoteIconUrl;
+        _category = category;
+        _modYmlUrl = string.IsNullOrWhiteSpace(modYmlUrl) ? null : modYmlUrl;
     }
 
     public string Repo { get; }
@@ -75,7 +78,20 @@ public class ModEntry : INotifyPropertyChanged
         }
     }
 
-    public string? RemoteIconUrl { get; }
+    public string? RemoteIconUrl
+    {
+        get => _remoteIconUrl;
+        private set
+        {
+            if (_remoteIconUrl == value)
+            {
+                return;
+            }
+
+            _remoteIconUrl = value;
+            OnPropertyChanged(nameof(RemoteIconUrl));
+        }
+    }
 
     public string? IconUrl
     {
@@ -95,9 +111,35 @@ public class ModEntry : INotifyPropertyChanged
 
     public bool HasIcon => !string.IsNullOrWhiteSpace(IconUrl);
 
-    public ModCategory Category { get; }
+    public ModCategory Category
+    {
+        get => _category;
+        private set
+        {
+            if (_category == value)
+            {
+                return;
+            }
 
-    public string? ModYmlUrl { get; }
+            _category = value;
+            OnPropertyChanged(nameof(Category));
+        }
+    }
+
+    public string? ModYmlUrl
+    {
+        get => _modYmlUrl;
+        private set
+        {
+            if (_modYmlUrl == value)
+            {
+                return;
+            }
+
+            _modYmlUrl = value;
+            OnPropertyChanged(nameof(ModYmlUrl));
+        }
+    }
 
     private IReadOnlyList<ModBadge> _badges = Array.Empty<ModBadge>();
 
@@ -168,6 +210,12 @@ public class ModEntry : INotifyPropertyChanged
     public void SetLoadingBadges(bool isLoading) => IsLoadingBadges = isLoading;
 
     public void SetIconPath(string? iconPath) => IconUrl = string.IsNullOrWhiteSpace(iconPath) ? null : iconPath;
+
+    public void UpdateCategory(ModCategory category) => Category = category;
+
+    public void UpdateModYmlUrl(string? modYmlUrl) => ModYmlUrl = string.IsNullOrWhiteSpace(modYmlUrl) ? null : modYmlUrl;
+
+    public void UpdateRemoteIcon(string? iconUrl) => RemoteIconUrl = string.IsNullOrWhiteSpace(iconUrl) ? null : iconUrl;
 
     private static string FormatDate(string prefix, DateTime? value) => value.HasValue
         ? $"{prefix}: {value.Value.ToLocalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"


### PR DESCRIPTION
## Summary
- generate a runtime "no icon" placeholder and surface it when icon downloads fail offline while pruning stale cached files
- implement `UpdateModAsync` to refresh metadata, badges, and cached icons while removing icons that no longer exist
- expose an Update Metadata context menu action to trigger the refresh from the UI

## Testing
- dotnet build OpenKh.Tools.ModBrowser/OpenKh.Tools.ModBrowser.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ccbd50dc832993cdbc91dc9b8260